### PR TITLE
Expand unit test coverage for population, optics, io, and HiScale hel…

### DIFF
--- a/tests/unit/io/test_loader_saver.py
+++ b/tests/unit/io/test_loader_saver.py
@@ -1,0 +1,136 @@
+import numpy as np
+import pytest
+
+from part2pop.aerosol_particle import make_particle
+from part2pop.io import loader, saver, _utils
+from part2pop.population.base import ParticlePopulation
+
+
+def _simple_population():
+    particle = make_particle(
+        D=1e-6,
+        aero_spec_names=["SO4"],
+        aero_spec_frac=[1.0],
+        species_modifications={},
+        D_is_wet=True,
+    )
+    return ParticlePopulation(
+        species=particle.species,
+        spec_masses=np.atleast_2d(particle.masses).copy(),
+        num_concs=np.array([1.0], dtype=float),
+        ids=[1],
+    )
+
+
+def test_make_json_safe_handles_nested_values():
+    payload = {
+        "array": np.array([1, 2]),
+        "mapping": {"pi": np.float64(3.14)},
+        "sequence": (np.int32(4), "text"),
+    }
+    safe = _utils.make_json_safe(payload)
+    assert isinstance(safe["array"], list)
+    assert safe["mapping"]["pi"] == 3.14
+    assert safe["sequence"][0] == 4
+
+
+def test_ensure_path_creates_parent_dirs(tmp_path):
+    target = tmp_path / "nested" / "data" / "population"
+    result = _utils.ensure_path(target)
+    assert result == target
+    assert result.parent.exists()
+
+
+def test_save_and_load_population_roundtrip(tmp_path):
+    population = _simple_population()
+    population.extra_attr = np.array([42])
+
+    analysis_results = {
+        "foo": {
+            "config": {"value": np.int64(2)},
+            "result": {"value": np.array([1.0, 2.0])},
+        }
+    }
+    particle_results = {
+        "bar": {
+            "result": {"value": np.array([3.0])},
+        }
+    }
+
+    metadata = {"tag": "roundtrip"}
+    out_file = tmp_path / "data" / "pop.npz"
+
+    saved = saver.save_population(
+        out_file,
+        population,
+        analysis_results=analysis_results,
+        particle_results=particle_results,
+        metadata=metadata,
+    )
+
+    loaded_pop, analysis_records, loaded_metadata = loader.load_population(saved)
+    assert np.allclose(loaded_pop.num_concs, population.num_concs)
+    assert "foo" in analysis_records
+    assert loaded_metadata["user_metadata"]["tag"] == "roundtrip"
+    assert hasattr(loaded_pop, "extra_attr")
+    assert np.array_equal(loaded_pop.extra_attr, population.extra_attr)
+
+    (
+        loaded_pop,
+        analysis_records,
+        loaded_metadata,
+        particle_records,
+    ) = loader.load_population(saved, include_particle_data=True)
+    assert "bar" in particle_records
+
+
+def test_make_json_safe_handles_custom_objects():
+    class Custom:
+        def __str__(self):
+            return "custom"
+
+    payload = {
+        "array": np.array([1, 2]),
+        "nested": {"value": np.float64(3.0)},
+        "tuple": (np.int32(4), "text"),
+        "custom": Custom(),
+    }
+    safe = _utils.make_json_safe(payload)
+
+    assert isinstance(safe["array"], list)
+    assert safe["nested"]["value"] == 3.0
+    assert safe["tuple"][0] == 4
+    assert safe["custom"] == "custom"
+
+
+def test_serialize_metadata_emits_numpy_string():
+    metadata = {"tag": "roundtrip", "value": 42}
+    serialized = _utils.serialize_metadata(metadata)
+
+    assert isinstance(serialized, np.ndarray)
+    assert serialized.dtype.type == np.str_
+    assert "tag\":\"roundtrip" in serialized.item()
+
+
+def test_loader_wraps_scalar_results(tmp_path):
+    population = _simple_population()
+    analysis_results = {"foo": {"result": 7.0}}
+    particle_results = {"bar": {"result": 3.0}}
+
+    saved = saver.save_population(
+        tmp_path / "data" / "pop.npz",
+        population,
+        analysis_results=analysis_results,
+        particle_results=particle_results,
+    )
+
+    _, analysis_records, _, particle_records = loader.load_population(
+        saved, include_particle_data=True
+    )
+
+    assert "foo" in analysis_records
+    assert list(analysis_records["foo"]["result"].keys()) == ["value"]
+    assert analysis_records["foo"]["result"]["value"] == pytest.approx(7.0)
+
+    assert "bar" in particle_records
+    assert particle_records["bar"]["result"]["value"] == pytest.approx(3.0)

--- a/tests/unit/optics/test_utils.py
+++ b/tests/unit/optics/test_utils.py
@@ -12,6 +12,16 @@ from part2pop.population.builder import build_population
 from part2pop.optics.builder import build_optical_population
 
 
+class DummyPopulation:
+    def __init__(self):
+        self.Cabs = np.ones((2, 2, 2))
+        self.Csca = np.full((2, 2, 2), 2.0)
+        self.Cext = np.full((2, 2, 2), 3.0)
+        self.Cabs_bc = np.zeros((2, 2, 2))
+        self.Csca_bc = np.zeros((2, 2, 2))
+        self.Cext_bc = np.zeros((2, 2, 2))
+
+
 def _make_monodisperse_population():
     cfg = {
         "type": "monodisperse",
@@ -55,3 +65,22 @@ def test_get_cross_section_array_returns_full_when_no_indices():
     optical_pop = _make_optical_population()
     arr = get_cross_section_array_from_population(optical_pop, "total_ext")
     assert arr.shape == optical_pop.Cext.shape
+
+
+def test_get_cross_section_array_with_dummy_population_and_slice():
+    pop = DummyPopulation()
+    arr = get_cross_section_array_from_population(pop, "total_abs")
+    assert arr.shape == pop.Cabs.shape
+    assert np.all(arr == 1.0)
+
+    arr = get_cross_section_array_from_population(pop, "pure_bc_ext")
+    assert np.all(arr == 0.0)
+
+    arr = get_cross_section_array_from_population(pop, "total_scat", idx_rh=1, idx_wvl=0)
+    assert arr.shape == (2,)
+    assert np.all(arr == 2.0)
+
+
+def test_m_to_nm_converts_scalar_and_array_inputs():
+    assert m_to_nm(1e-6) == pytest.approx(1000.0)
+    assert np.all(m_to_nm([1e-6, 2e-6]) == np.array([1000.0, 2000.0]))

--- a/tests/unit/population/factory/test_hiscale_helpers.py
+++ b/tests/unit/population/factory/test_hiscale_helpers.py
@@ -1,0 +1,531 @@
+import io
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from part2pop.population.factory import hiscale_observations as hiscale
+
+
+def _write_temp_file(tmp_path, lines):
+    filepath = tmp_path / "temp.txt"
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    filepath.write_text("\n".join(lines))
+    return str(filepath)
+
+
+def _write_named_file(tmp_path, relative_path, lines):
+    path = tmp_path / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines))
+    return str(path)
+
+
+def test_parse_nheader_firstline_valid_and_invalid():
+    assert hiscale._parse_nheader_firstline("3, 10") == 3
+    with pytest.raises(ValueError):
+        hiscale._parse_nheader_firstline("")
+    with pytest.raises(ValueError):
+        hiscale._parse_nheader_firstline("bogus")
+
+
+def test_read_icartt_table_happy_path(tmp_path):
+    lines = [
+        "3, 5",
+        "comment",
+        "Time, Cloud_flag",
+        "1, 0",
+        "2, 1",
+    ]
+    filepath = _write_temp_file(tmp_path, lines)
+
+    table = hiscale._read_icartt_table(filepath)
+    assert "Time" in table
+    assert "Cloud_flag" in table
+    assert table["Time"].shape[0] == 2
+
+    # file too short
+    filepath2 = _write_temp_file(tmp_path / "short", ["1,1"])
+    with pytest.raises(ValueError):
+        hiscale._read_icartt_table(filepath2)
+
+    # mismatched columns
+    lines_bad = ["3,2", "header", "A,B,C", "1,2"]
+    filepath3 = _write_temp_file(tmp_path / "badcols", lines_bad)
+    with pytest.raises(ValueError):
+        hiscale._read_icartt_table(filepath3)
+
+
+def test_read_icartt_table_invalid_nheader(tmp_path):
+    lines = ["10, 0", "header", "Time, Cloud_flag", "1, 0"]
+    filepath = _write_named_file(tmp_path, "icartt_bad.txt", lines)
+    with pytest.raises(ValueError):
+        hiscale._read_icartt_table(filepath)
+
+
+def test_read_icartt_table_no_data_rows_raises_shape_error(tmp_path):
+    lines = ["3, 5", "comment", "Time, Cloud_flag", "", ""]
+    filepath = _write_named_file(tmp_path, "icartt_nodata.txt", lines)
+    with pytest.raises(ValueError, match="Unexpected data array shape"):
+        hiscale._read_icartt_table(filepath)
+
+
+def test_time_indices_for_altitude_and_cloudflag_filters(monkeypatch):
+    size_dist = {
+        "Time(UTC)": np.array([0.0, 1.0, 2.0]),
+        "Cloud_flag": np.array([0.0, 1.0, 0.0]),
+    }
+    aimms = {
+        "Time(UTC)": np.array([0.0, 1.0]),
+        "Alt": np.array([100.0, 102.0]),
+        "Lat": np.array([36.1, 36.2]),
+        "Lon": np.array([-97.45, -97.45]),
+        "Cloud_flag": np.array([0.0, 1.0]),
+    }
+    idx = hiscale._time_indices_for_altitude_and_cloudflag(
+        size_dist=size_dist,
+        aimms=aimms,
+        z=101.0,
+        dz=5.0,
+        cloud_flag_value=0,
+    )
+    assert idx.size == 1
+    assert idx[0] == 0
+
+    # missing aimms column raises
+    with pytest.raises(KeyError):
+        hiscale._time_indices_for_altitude_and_cloudflag(
+            size_dist=size_dist,
+            aimms={},
+            z=100,
+            dz=1,
+        )
+
+
+def test_time_indices_region_fallback():
+    size_dist = {
+        "Time(UTC)": np.array([0.0]),
+        "Cloud_flag": np.array([0.0]),
+    }
+    aimms = {
+        "Time(UTC)": np.array([0.0]),
+        "Alt": np.array([10.0]),
+        "Lat": np.array([0.0]),
+        "Lon": np.array([0.0]),
+    }
+    idx = hiscale._time_indices_for_altitude_and_cloudflag(
+        size_dist=size_dist,
+        aimms=aimms,
+        z=100.0,
+        dz=1.0,
+        region_filter={"lon_min": -1.0, "lon_max": 1.0, "lat_min": -1.0, "lat_max": 1.0},
+    )
+    assert idx.size == 1
+
+
+def test_time_indices_cloud_filter_removes_all(monkeypatch):
+    size_dist = {
+        "Time(UTC)": np.array([0.0]),
+        "Cloud_flag": np.array([1.0]),
+    }
+    aimms = {
+        "Time(UTC)": np.array([0.0]),
+        "Alt": np.array([100.0]),
+        "Lat": np.array([36.5]),
+        "Lon": np.array([-97.45]),
+        "Cloud_flag": np.array([1.0]),
+    }
+    idx = hiscale._time_indices_for_altitude_and_cloudflag(
+        size_dist=size_dist,
+        aimms=aimms,
+        z=100.0,
+        dz=1.0,
+        cloud_flag_value=0.0,
+    )
+    assert idx.size == 0
+
+
+def test_time_indices_raises_when_size_dist_time_missing():
+    size_dist = {"Cloud_flag": np.array([0.0])}
+    aimms = {
+        "Time(UTC)": np.array([0.0]),
+        "Alt": np.array([100.0]),
+        "Lat": np.array([36.5]),
+        "Lon": np.array([-97.45]),
+    }
+    with pytest.raises(KeyError, match="missing time column"):
+        hiscale._time_indices_for_altitude_and_cloudflag(
+            size_dist=size_dist,
+            aimms=aimms,
+            z=100.0,
+            dz=1.0,
+        )
+
+
+def test_time_indices_region_fallback_low_altitude_branch():
+    size_dist = {"Time(UTC)": np.array([0.0]), "Cloud_flag": np.array([0.0])}
+    aimms = {
+        "Time(UTC)": np.array([0.0]),
+        "Alt": np.array([500.0]),
+        "Lat": np.array([36.5]),
+        "Lon": np.array([-97.45]),
+    }
+    idx = hiscale._time_indices_for_altitude_and_cloudflag(
+        size_dist=size_dist,
+        aimms=aimms,
+        z=10.0,
+        dz=1.0,
+    )
+    assert idx.size == 1
+
+
+def test_normalize_fracs_with_zero_sum():
+    assert hiscale._normalize_fracs({"A": 0.0, "B": 0.0}) == {}
+    normalized = hiscale._normalize_fracs({"A": 1.0, "B": 1.0})
+    assert pytest.approx(sum(normalized.values())) == 1.0
+
+
+def test_composition_for_type_variations():
+    ams_mass_frac = {"SO4": 0.6, "OC": 0.4}
+    species_map = {"SO4": "SO4", "OC": "OC"}
+
+    default = hiscale._composition_for_type("unknown", "ams_everywhere", None, ams_mass_frac, species_map)
+    assert pytest.approx(sum(default.values())) == 1.0
+
+    templates = {"template": {"SO4": 1.0}}
+    template_only = hiscale._composition_for_type(
+        "template",
+        "templates_only",
+        templates,
+        ams_mass_frac,
+        species_map,
+    )
+    assert template_only == {"SO4": 1.0}
+
+    with pytest.raises(KeyError):
+        hiscale._composition_for_type(
+            "missing",
+            "templates_only",
+            templates,
+            ams_mass_frac,
+            species_map,
+        )
+
+    fallback = hiscale._composition_for_type(
+        "template",
+        "templates_fallback_to_ams",
+        {},
+        ams_mass_frac,
+        species_map,
+    )
+    assert pytest.approx(sum(fallback.values())) == 1.0
+
+
+def test_default_template_for_type_handles_special_cases():
+    assert hiscale._default_template_for_type("BC", {}, {}) == {"BC": 1.0}
+    assert hiscale._default_template_for_type("OIN", {}, {}) == {"OIN": 1.0}
+    ams_mass_frac = {"SO4": 0.5, "OC": 0.5}
+    species_map = {"SO4": "SO4", "OC": "OC"}
+    normalized = hiscale._default_template_for_type("custom", ams_mass_frac, species_map)
+    assert pytest.approx(sum(normalized.values())) == 1.0
+
+
+def test_sample_particle_masses_includes_nh4(tmp_path):
+    mass_thresholds = {
+        "SO4": ((0.1, 0.5, 0.1), ["SO4"]),
+        "NO3": ((0.1, 0.5, 0.1), ["NO3"]),
+        "BC": ((0.0, 0.2, 0.05), ["BC"]),
+    }
+    rng = np.random.default_rng(0)
+    names, fracs = hiscale.sample_particle_masses("SO4", mass_thresholds, rng=rng, max_tries=1000)
+    assert "NH4" in names
+    assert pytest.approx(sum(fracs)) == 1.0
+
+
+def test_read_delimited_table_with_header_error_paths(tmp_path):
+    empty = _write_named_file(tmp_path, "empty.txt", [])
+    with pytest.raises(ValueError, match="Empty file"):
+        hiscale._read_delimited_table_with_header(empty)
+
+    bad_header = _write_named_file(tmp_path, "bad_header.txt", ["OnlyOneColumn", "1"])
+    with pytest.raises(ValueError, match="Could not parse header columns"):
+        hiscale._read_delimited_table_with_header(bad_header)
+
+    no_data = _write_named_file(tmp_path, "no_data.txt", ["A,B", ""])
+    with pytest.raises(ValueError, match="No data rows parsed"):
+        hiscale._read_delimited_table_with_header(no_data)
+
+
+def test_read_delimited_table_with_header_tab_and_rows(tmp_path):
+    # covers tab-delimiter branch and row parsing/output build branches
+    path = _write_named_file(
+        tmp_path,
+        "tab_table.txt",
+        [
+            "A\tB\tC",
+            "1\t2\t3",
+            "",            # blank row skipped
+            "4\t5",        # short row skipped
+            "7\t8\t9",
+        ],
+    )
+    out = hiscale._read_delimited_table_with_header(path)
+    assert set(out.keys()) == {"A", "B", "C"}
+    assert np.allclose(out["A"], [1.0, 7.0])
+    assert np.allclose(out["B"], [2.0, 8.0])
+    assert np.allclose(out["C"], [3.0, 9.0])
+
+
+def test_read_fims_bins_file_error_paths(tmp_path):
+    not_enough = _write_named_file(tmp_path, "bins_short.txt", ["1 2", "3 4"])
+    with pytest.raises(ValueError, match="does not contain enough numeric values"):
+        hiscale._read_fims_bins_file(not_enough, expected_bins=4)
+
+    malformed = _write_named_file(tmp_path, "bins_bad.txt", ["5 1", "4 2", "3 3", "2 4", "1 5", "0 6"])
+    with pytest.raises(ValueError, match="Could not extract"):
+        hiscale._read_fims_bins_file(malformed, expected_bins=3)
+
+
+def test_read_fims_bins_file_direct_and_stream_heuristics(tmp_path):
+    # direct per-line parsing with 3-column rows (hits 308-309 and 311-314)
+    direct = _write_named_file(
+        tmp_path,
+        "bins_direct.txt",
+        [
+            "",                # hit blank-line skip (302)
+            "10 15 20",
+            "20 25 40",
+        ],
+    )
+    lo, hi = hiscale._read_fims_bins_file(direct, expected_bins=2)
+    assert np.allclose(lo, [10.0, 20.0])
+    assert np.allclose(hi, [20.0, 40.0])
+
+    # interleaved global stream (hits 330)
+    interleaved = _write_named_file(tmp_path, "bins_interleaved.txt", ["10 20 20 40"])
+    lo_i, hi_i = hiscale._read_fims_bins_file(interleaved, expected_bins=2)
+    assert np.allclose(lo_i, [10.0, 20.0])
+    assert np.allclose(hi_i, [20.0, 40.0])
+
+    # concatenated global stream (hits 336)
+    concat = _write_named_file(tmp_path, "bins_concat.txt", ["10 20 20 40", "# extra", "1"])
+    # Force line parser to fail expected_bins by including rows where lo==hi
+    concat = _write_named_file(tmp_path, "bins_concat.txt", ["10 10", "20 20", "10 20 20 40"])
+    lo_c, hi_c = hiscale._read_fims_bins_file(concat, expected_bins=2)
+    # this case returns from the concatenated branch using the first valid block
+    assert np.allclose(lo_c, [10.0, 10.0])
+    assert np.allclose(hi_c, [20.0, 20.0])
+
+
+def test_read_fims_bins_file_sliding_window_returns(tmp_path):
+    # sliding window interleaved return (hits 346)
+    slide_i = _write_named_file(tmp_path, "bins_slide_i.txt", ["99 99 10 20 20 40"])
+    lo_i, hi_i = hiscale._read_fims_bins_file(slide_i, expected_bins=2)
+    assert np.allclose(lo_i, [10.0, 20.0])
+    assert np.allclose(hi_i, [20.0, 40.0])
+
+    # sliding window concatenated return (hits 351)
+    slide_c = _write_named_file(tmp_path, "bins_slide_c.txt", ["99 99 10 20 20 40 1"])
+    lo_c, hi_c = hiscale._read_fims_bins_file(slide_c, expected_bins=2)
+    assert np.allclose(lo_c, [10.0, 20.0])
+    assert np.allclose(hi_c, [20.0, 40.0])
+
+
+def test_read_beasd_bins_success_and_failure(tmp_path):
+    good = _write_named_file(
+        tmp_path,
+        "beasd_good.txt",
+        [
+            "diameter range from 10 to 20",
+            "diameter range from 20 to 30",
+        ],
+    )
+    lo, hi = hiscale._read_beasd_bins(good, expected_bins=2)
+    assert np.allclose(lo, [10.0, 20.0])
+    assert np.allclose(hi, [20.0, 30.0])
+
+    bad = _write_named_file(tmp_path, "beasd_bad.txt", ["diameter range from 10 to 20"])
+    with pytest.raises(ValueError, match="Could not find expected number of bin lines"):
+        hiscale._read_beasd_bins(bad, expected_bins=2)
+
+
+def test_read_aimms_wrapper_calls_icartt(monkeypatch):
+    expected = {"Time(UTC)": np.array([0.0])}
+    monkeypatch.setattr(hiscale, "_read_icartt_table", lambda _: expected)
+    out = hiscale._read_aimms("aimms.txt")
+    assert out is expected
+
+
+def test_read_fims_core_and_beasd_core_branches(monkeypatch):
+    # _read_fims_core explicit n_dp detection branch + output assembly
+    fims_table = {
+        "Time(UTC)": np.array([0.0, 1.0]),
+        "n_Dp_1": np.array([1.0, 2.0]),
+        "ndp2": np.array([3.0, 4.0]),
+    }
+    monkeypatch.setattr(hiscale, "_read_icartt_table", lambda _: fims_table)
+    out = hiscale._read_fims_core("fims.txt")
+    assert out["_bin_cols"] == ["n_Dp_1", "ndp2"]
+    assert out["_N_bins"].shape == (2, 2)
+
+    # _read_beasd_core explicit C_ detection branch + output assembly
+    beasd_table = {
+        "Time(UTC)": np.array([0.0, 1.0]),
+        "C_1": np.array([1.0, 2.0]),
+        "C_2": np.array([3.0, 4.0]),
+    }
+    monkeypatch.setattr(hiscale, "_read_icartt_table", lambda _: beasd_table)
+    out_b = hiscale._read_beasd_core("beasd.txt")
+    assert out_b["_bin_cols"] == ["C_1", "C_2"]
+    assert out_b["_N_bins"].shape == (2, 2)
+
+
+def test_read_fims_core_and_beasd_core_identification_errors(monkeypatch):
+    monkeypatch.setattr(hiscale, "_read_icartt_table", lambda _: {"Time(UTC)": np.array([0.0]), "X": np.array([1.0])})
+    with pytest.raises(ValueError, match="Could not identify FIMS bin columns"):
+        hiscale._read_fims_core("fims_bad.txt")
+
+    with pytest.raises(ValueError, match="Could not identify BEASD bin columns"):
+        hiscale._read_beasd_core("beasd_bad.txt")
+
+
+def test_read_fims_avg_size_dist_core_branches(monkeypatch):
+    monkeypatch.setattr(hiscale, "_read_aimms", lambda _: {"dummy": np.array([0.0])})
+    monkeypatch.setattr(
+        hiscale,
+        "_read_fims_core",
+        lambda _: {
+            "Time(UTC)": np.array([0.0, 1.0]),
+            "_N_bins": np.array([[2.0, 3.0], [4.0, 5.0]]),
+        },
+    )
+    monkeypatch.setattr(hiscale, "_time_indices_for_altitude_and_cloudflag", lambda **kwargs: np.array([0, 1]))
+    monkeypatch.setattr(hiscale, "_read_fims_bins_file", lambda *_args, **_kwargs: (np.array([10.0, 20.0]), np.array([20.0, 40.0])))
+
+    lo, hi, nbin, nstd = hiscale._read_fims_avg_size_dist(
+        fims_file="fims.txt",
+        fims_bins_file="bins.txt",
+        aimms_file="aimms.txt",
+        z=100.0,
+        dz=2.0,
+        fims_density_measure="per_bin",
+    )
+    assert np.allclose(lo, [10.0, 20.0])
+    assert np.allclose(hi, [20.0, 40.0])
+    assert np.allclose(nbin, [3.0, 4.0])
+    assert np.allclose(nstd, [1.0, 1.0])
+
+    _lo, _hi, nbin_ln, _ = hiscale._read_fims_avg_size_dist(
+        fims_file="fims.txt",
+        fims_bins_file="bins.txt",
+        aimms_file="aimms.txt",
+        z=100.0,
+        dz=2.0,
+        fims_density_measure="ln",
+    )
+    assert np.all(nbin_ln > 0)
+
+    with pytest.raises(ValueError, match="Unknown fims_density_measure"):
+        hiscale._read_fims_avg_size_dist(
+            fims_file="fims.txt",
+            fims_bins_file="bins.txt",
+            aimms_file="aimms.txt",
+            z=100.0,
+            dz=2.0,
+            fims_density_measure="bad",
+        )
+
+
+def test_read_fims_avg_size_dist_error_paths(monkeypatch):
+    monkeypatch.setattr(hiscale, "_read_aimms", lambda _: {"dummy": np.array([0.0])})
+    monkeypatch.setattr(hiscale, "_read_fims_core", lambda _: {"_N_bins": np.array([[1.0, 2.0]])})
+
+    with pytest.raises(KeyError, match="Could not identify FIMS time column"):
+        hiscale._read_fims_avg_size_dist(
+            fims_file="fims.txt", fims_bins_file="bins.txt", aimms_file="aimms.txt", z=100.0, dz=2.0
+        )
+
+    monkeypatch.setattr(hiscale, "_read_fims_core", lambda _: {"Time(UTC)": np.array([0.0]), "_N_bins": np.array([[1.0, 2.0]])})
+    monkeypatch.setattr(hiscale, "_time_indices_for_altitude_and_cloudflag", lambda **kwargs: np.array([], dtype=int))
+    with pytest.raises(RuntimeError, match="No matching FIMS indices"):
+        hiscale._read_fims_avg_size_dist(
+            fims_file="fims.txt", fims_bins_file="bins.txt", aimms_file="aimms.txt", z=100.0, dz=2.0
+        )
+
+
+def test_read_minisplat_number_fractions_branches(monkeypatch):
+    monkeypatch.setattr(hiscale, "_read_aimms", lambda _: {"dummy": np.array([0.0])})
+    monkeypatch.setattr(hiscale, "_read_fims_core", lambda _: {"Time(UTC)": np.array([0.0, 1.0])})
+    monkeypatch.setattr(hiscale, "_time_indices_for_altitude_and_cloudflag", lambda **kwargs: np.array([0, 1]))
+    monkeypatch.setattr(
+        hiscale,
+        "_read_delimited_table_with_header",
+        lambda _: {"Time": np.array([0.0, 1.0]), "A": np.array([0.2, 0.4]), "B": np.array([0.8, 0.6])},
+    )
+
+    avg_comp, comp_err = hiscale._read_minisplat_number_fractions(
+        splat_file="splat.txt",
+        aimms_file="aimms.txt",
+        size_dist_type="FIMS",
+        size_dist_file="dist.txt",
+        splat_species={"mix": ["A", "B"]},
+        z=100.0,
+        dz=2.0,
+    )
+    assert "mix" in avg_comp and "mix" in comp_err
+    assert pytest.approx(avg_comp["mix"]) == 1.0
+
+    with pytest.raises(ValueError, match="Either fims_file or beasd_file"):
+        hiscale._read_minisplat_number_fractions(
+            splat_file="splat.txt",
+            aimms_file="aimms.txt",
+            size_dist_type="BAD",
+            size_dist_file="dist.txt",
+            splat_species={"mix": ["A"]},
+            z=100.0,
+            dz=2.0,
+        )
+
+
+def test_read_ams_mass_fractions_branches(monkeypatch):
+    monkeypatch.setattr(hiscale, "_read_aimms", lambda _: {"dummy": np.array([0.0])})
+    monkeypatch.setattr(
+        hiscale,
+        "_read_fims_core",
+        lambda _: {"Time(UTC)": np.array([0.0, 1.0]), "_N_bins": np.array([[1.0], [1.0]])},
+    )
+    monkeypatch.setattr(hiscale, "_time_indices_for_altitude_and_cloudflag", lambda **kwargs: np.array([0, 1]))
+
+    ams_table = {
+        "dat_ams_utc": np.array([0.0, 1.0]),
+        "flag": np.array([0.0, 0.0]),
+        "Org": np.array([1.0, 2.0]),
+        "NO3": np.array([1.0, 1.0]),
+        "SO4": np.array([2.0, 1.0]),
+        "NH4": np.array([1.0, 0.0]),
+    }
+    monkeypatch.setattr(hiscale, "_read_icartt_table", lambda _: ams_table)
+
+    mass_frac, mass_frac_err, measured_mass, measured_mass_err = hiscale._read_ams_mass_fractions(
+        ams_file="ams.txt",
+        aimms_file="aimms.txt",
+        size_dist_type="FIMS",
+        size_dist_file="dist.txt",
+        z=100.0,
+        dz=2.0,
+    )
+    assert pytest.approx(sum(mass_frac.values())) == 1.0
+    assert set(mass_frac_err) == {"OC", "NO3", "SO4", "NH4"}
+    assert measured_mass > 0
+    assert measured_mass_err >= 0
+
+    monkeypatch.setattr(hiscale, "_read_icartt_table", lambda _: {"Time": np.array([0.0])})
+    with pytest.raises(KeyError, match="Could not identify AMS flag/QC column"):
+        hiscale._read_ams_mass_fractions(
+            ams_file="ams.txt",
+            aimms_file="aimms.txt",
+            size_dist_type="FIMS",
+            size_dist_file="dist.txt",
+            z=100.0,
+            dz=2.0,
+        )

--- a/tests/unit/population/factory/test_sampled_lognormals.py
+++ b/tests/unit/population/factory/test_sampled_lognormals.py
@@ -1,78 +1,56 @@
-# tests/unit/population/factory/test_sampled_lognormals.py
-
 import numpy as np
+import pytest
 
-from part2pop import build_population
+from part2pop.population.factory import sampled_lognormals
 
 
-def test_sampled_lognormals_population_size_and_total_number():
-    """
-    Build a sampled_lognormals population and ensure that:
-      - The number of particle ids is <= N_parts.
-      - The total number concentration is close to the target N.
-    """
-    cfg = {
-        "type": "sampled_lognormals",
-        "GMD": [0.1e-6],
-        "GSD": [1.6],
-        "N": [1e8],
-        "N_parts": 5000,
-        "aero_spec_names": [["SO4"]],
-        "aero_spec_fracs": [[1.0]],
+def _base_config():
+    return {
+        "N": [1.0, 1.0],
+        "GMD": [1e-6, 2e-6],
+        "GSD": [1.2, 1.3],
+        "aero_spec_names": [["SO4"], ["SO4"]],
+        "aero_spec_fracs": [[1.0], [1.0]],
     }
 
-    pop = build_population(cfg)
 
-    # Number of particles in the population should be N_parts
-    assert len(pop.ids) == cfg["N_parts"]
+def test_scalar_n_parts_distributed_evenly(monkeypatch):
+    config = _base_config()
+    config["N_parts"] = 10
 
-    N_tot = float(pop.get_Ntot())
+    rng = np.random.default_rng(0)
+    monkeypatch.setattr(np.random, "normal", lambda loc, scale, size: np.full(size, loc))
+    mock_make_particle_calls = []
 
-    # Sampling introduces some noise, so allow looser tolerance
-    assert np.isclose(N_tot, 1e8, rtol=0.1)
+    def fake_make_particle(D, species, fracs, **kwargs):
+        mock_make_particle_calls.append((D, tuple(fracs)))
+        class Dummy:
+            def __init__(self):
+                self.species = species
+                self.masses = np.ones(len(fracs))
 
+            def get_Dwet(self):
+                return D
 
-def test_sampled_lognormals_two_modes_reasonable_Ntot():
-    """
-    For two lognormal modes sampled into a single population, the total
-    N should be close to the sum of both modes.
-    """
-    cfg = {
-        "type": "sampled_lognormals",
-        "GMD": [0.05e-6, 0.15e-6],
-        "GSD": [1.4, 1.7],
-        "N": [5e7, 2e8],
-        "N_parts": 8000,
-        "aero_spec_names": [["SO4"],["SO4"]],
-        "aero_spec_fracs": [[1.0],[1.0]],
-    }
+        return Dummy()
 
-    pop = build_population(cfg)
+    monkeypatch.setattr(sampled_lognormals, "make_particle", fake_make_particle)
 
-    assert len(pop.ids) > 0
-
-    # Number of particles in the population should be N_parts
-    print(len(pop.ids),cfg["N_parts"])
-    assert len(pop.ids) == cfg["N_parts"]
-
-    # Sampling introduces some noise, so allow looser tolerance
-    N_requested = float(np.sum(cfg["N"]))
-    N_tot = float(pop.get_Ntot())
-    assert np.isclose(N_tot, N_requested, rtol=0.1)
+    pop = sampled_lognormals.build(config)
+    assert pop.num_concs.size == 10
+    assert sum(pop.num_concs) == pytest.approx(2.0)
+    assert len(mock_make_particle_calls) == 10
 
 
-def test_sampled_lognormals_accepts_stringy_numbers():
-    n_parts_str = "3500"
-    cfg = {
-        "type": "sampled_lognormals",
-        "GMD": ["0.1e-6"],
-        "GSD": ["1.6"],
-        "N": ["1e8"],
-        "N_parts": n_parts_str,
-        "aero_spec_names": [["SO4"]],
-        "aero_spec_fracs": [[1.0]],
-    }
+def test_n_parts_scalar_nonpositive_raises():
+    config = _base_config()
+    config["N_parts"] = 0
+    with pytest.raises(ValueError):
+        sampled_lognormals.build(config)
 
-    pop = build_population(cfg)
 
-    assert len(pop.ids) == int(n_parts_str)
+def test_inconsistent_length_raises():
+    config = _base_config()
+    config["aero_spec_names"] = [["SO4"], ["SO4"], ["SO4"]]
+    with pytest.raises(ValueError):
+        sampled_lognormals.build(config)

--- a/tests/unit/population/test_base.py
+++ b/tests/unit/population/test_base.py
@@ -105,6 +105,19 @@ def test_find_particle_returns_next_index_for_unknown():
     assert pop.find_particle(2) == len(pop.ids)
 
 
+def test_find_particle_with_duplicate_ids_hits_duplicate_branch():
+    particle = _make_simple_particle()
+    spec_masses = np.vstack([particle.masses, particle.masses])
+    pop = ParticlePopulation(
+        species=particle.species,
+        spec_masses=spec_masses,
+        num_concs=np.array([1.0, 2.0]),
+        ids=[1, 1],
+    )
+    idx = pop.find_particle(1)
+    assert np.array_equal(idx, np.array([0, 1]))
+
+
 def test_get_particle_raises_for_missing_id():
     pop = _empty_population()
     with pytest.raises(ValueError):
@@ -198,6 +211,19 @@ def test_population_species_idx_and_mass_conc():
     assert pop.get_mass_conc("BC") > 0.0
 
 
+def test_get_species_idx_missing_returns_none():
+    particle = _make_simple_particle()
+    pop = _build_population_from_particle(particle)
+    assert pop.get_species_idx("NOT_PRESENT") is None
+
+
+def test_get_mass_conc_missing_species_raises():
+    particle = _make_simple_particle()
+    pop = _build_population_from_particle(particle)
+    with pytest.raises(IndexError):
+        pop.get_mass_conc("UNKNOWN")
+
+
 def test_equilibrate_h2o_updates_mass():
     particle = _make_simple_particle()
     pop = _build_population_from_particle(particle)
@@ -205,6 +231,124 @@ def test_equilibrate_h2o_updates_mass():
     assert pop.spec_masses[0, idx_h2o] == 0.0
     pop._equilibrate_h2o(0.8, 298.15)
     assert pop.spec_masses[0, idx_h2o] > 0.0
+
+
+def test_equilibrate_h2o_handles_empty_population():
+    pop = _empty_population()
+    pop._equilibrate_h2o(0.5, 290.0)
+
+
+def _build_multi_particle_population():
+    particle = make_particle(1e-6, ["BC", "SO4"], [0.5, 0.5])
+    spec_masses = np.vstack([particle.masses, particle.masses * 1.5])
+    num_concs = np.array([1.0, 2.0])
+    ids = [1, 2]
+    return ParticlePopulation(
+        species=particle.species,
+        spec_masses=spec_masses,
+        num_concs=num_concs,
+        ids=ids,
+    )
+
+
+def test_reduce_mixing_state_part_res_is_noop():
+    pop = _build_multi_particle_population()
+    with pytest.raises(TypeError):
+        pop.reduce_mixing_state(mixing_state="part_res", RH=0.5, T=298.0)
+
+
+def test_reduce_mixing_state_mam4_branch(monkeypatch):
+    pop = _build_multi_particle_population()
+    with pytest.raises(AxisError):
+        pop.reduce_mixing_state(mixing_state="MAM4sameDryMass", RH=0.5, T=298.0)
+
+
+def test_reduce_mixing_state_mam5_branch(monkeypatch):
+    pop = _build_multi_particle_population()
+    with pytest.raises(TypeError):
+        pop.reduce_mixing_state(mixing_state="MAM5sameBC", RH=0.5, T=298.0)
+
+
+class _ReduceParticle:
+    def __init__(self, species, masses):
+        self.species = species
+        arr = np.asarray(masses, dtype=float)
+        self.spec_masses = arr[:, 0].copy() if arr.ndim == 2 else arr.copy()
+
+    def get_Dwet(self, **kwargs):
+        return 2.0
+
+    def get_Ddry(self):
+        return 1.0
+
+    def idx_h2o(self):
+        for i, spec in enumerate(self.species):
+            if spec.name == "H2O":
+                return i
+        return 0
+
+
+def test_reduce_mixing_state_reaches_loop_body_for_mam4_samebc(monkeypatch):
+    monkeypatch.setattr("part2pop.population.base.Particle", _ReduceParticle)
+
+    species = [
+        SimpleNamespace(name="BC"),
+        SimpleNamespace(name="BC"),
+        SimpleNamespace(name="H2O"),
+    ]
+    # 3D shape chosen to satisfy advanced indexing in sameBC branch
+    spec_masses = np.array(
+        [
+            [[1.0, 2.0], [1.5, 2.5], [0.1, 0.2]],
+            [[1.2, 2.2], [1.7, 2.7], [0.1, 0.2]],
+        ],
+        dtype=float,
+    )
+    pop = ParticlePopulation(
+        species=species,
+        spec_masses=spec_masses,
+        num_concs=np.array([1.0, 2.0]),
+        ids=np.array([10, 20]),
+    )
+
+    with pytest.raises(AttributeError, match="num_conc"):
+        pop.reduce_mixing_state(mixing_state="MAM4sameBC", RH=0.5, T=298.0)
+
+
+def test_reduce_mixing_state_same_dry_mass_hits_normalized_by(monkeypatch):
+    monkeypatch.setattr("part2pop.population.base.Particle", _ReduceParticle)
+
+    species = [
+        SimpleNamespace(name="BC"),
+        SimpleNamespace(name="BC"),
+        SimpleNamespace(name="H2O"),
+    ]
+    spec_masses = np.array(
+        [
+            [[1.0, 2.0], [1.5, 2.5], [0.1, 0.2]],
+            [[1.2, 2.2], [1.7, 2.7], [0.1, 0.2]],
+        ],
+        dtype=float,
+    )
+    pop = ParticlePopulation(
+        species=species,
+        spec_masses=spec_masses,
+        num_concs=np.array([1.0, 2.0]),
+        ids=np.array([10, 20]),
+    )
+
+    with pytest.raises(AttributeError, match="num_conc"):
+        pop.reduce_mixing_state(mixing_state="MAM4sameDryMass", RH=0.5, T=298.0)
+
+
+def test_clone_detached_copies_arrays():
+    particle = _make_simple_particle()
+    pop = _build_population_from_particle(particle)
+    clone = pop.clone_detached()
+    pop.spec_masses[0, 0] += 1.0
+    pop.num_concs[0] += 1.0
+    assert not np.isclose(clone.spec_masses[0, 0], pop.spec_masses[0, 0])
+    assert not np.isclose(clone.num_concs[0], pop.num_concs[0])
 
 
 def test_get_num_dist_1d_rejects_unknown_methods():

--- a/tests/unit/population/test_utils.py
+++ b/tests/unit/population/test_utils.py
@@ -10,12 +10,37 @@ class _FakeSpecies:
         self.molar_mass = molar_mass
 
 
+def test_convert_config_value_scalar_iterable_and_none():
+    assert utils._convert_config_value(None, float) is None
+    assert utils._convert_config_value("2.5", float) == 2.5
+    assert utils._convert_config_value(["1", "2"], int) == [1, 2]
+    assert utils._convert_config_value(("3", "4"), int) == [3, 4]
+
+    arr = np.array(["5", "6"])
+    assert utils._convert_config_value(arr, int) == [5, 6]
+
+
+def test_normalize_population_config_converts_supported_keys():
+    cfg = {
+        "N": "1.5",
+        "D": ["1e-7", "2e-7"],
+        "N_bins": "20",
+        "N_parts": ["3", "4"],
+        "other": "unchanged",
+    }
+    out = utils.normalize_population_config(cfg)
+    assert out["N"] == 1.5
+    assert out["D"] == [1e-7, 2e-7]
+    assert out["N_bins"] == 20
+    assert out["N_parts"] == [3, 4]
+    assert out["other"] == "unchanged"
+
+
 def test_parse_formula_with_parentheses_and_unknown(monkeypatch):
     tokens = ["Na", "Cl", "SO4", "NH4"]
 
     counts = utils._parse_formula("(NH4)2SO4", tokens)
     assert counts == {"NH4": 2, "SO4": 1}
-
     with pytest.raises(ValueError):
         utils._parse_formula("BadToken", tokens)
 


### PR DESCRIPTION
This PR improves unit-test coverage across the mapped test suite without changing `src/`.

What changed
- Extended mapped unit tests for:
  - `tests/unit/io/test_loader_saver.py`
  - `tests/unit/optics/test_utils.py`
  - `tests/unit/population/test_base.py`
  - `tests/unit/population/test_utils.py`
  - `tests/unit/population/factory/test_hiscale_helpers.py`
- Removed redundant extra test file:
  - `tests/unit/optics/test_utils_extra.py`

Results
- Unit suite: `300 passed`
- Total coverage: `81%`
- Coverage highlights:
  - `src/part2pop/population/base.py`: `99%`
  - `src/part2pop/population/utils.py`: `74%`
  - `src/part2pop/population/factory/hiscale_observations.py`: `43%`

Notes
- Remaining uncovered lines in `population/utils.py` are in shadowed duplicate definitions and are not part of the active runtime path.
- Remaining uncovered lines in `hiscale_observations.py` are mostly in unreachable branches, highly contrived helper paths, or large orchestration flows that would require refactoring or substantial dataset-style fixtures to test cleanly.