### PR TITLE
docs: add module extension guides

### DIFF
--- a/docs/analysis_variables.md
+++ b/docs/analysis_variables.md
@@ -1,0 +1,58 @@
+# Analysis Variables
+
+## What this module owns
+
+- Particle-level and population-level diagnostic variables.
+- Variable registration/discovery and metadata (`VariableMeta`).
+
+## Public API entry points
+
+- `build_variable(...)`
+- analysis variable builders under `src/part2pop/analysis/*/factory/`
+
+## List/describe registered components
+
+- Use existing analysis registry list/describe APIs where available.
+- Pattern aligns with other extension systems: list first, then describe selected variable.
+
+## How to add a new extension
+
+1. Choose scope:
+   - particle variable
+   - population variable
+2. Add a factory module in the corresponding analysis factory location.
+3. Define builder and attach `VariableMeta`.
+4. Ensure it is discoverable by existing analysis registry logic.
+
+## Required file location and naming pattern
+
+- Location: `src/part2pop/analysis/particle/factory/` or `src/part2pop/analysis/population/factory/`
+- Pattern: one variable per module, lowercase filename, no leading `_`.
+
+## Minimal code example
+
+```python
+from part2pop.analysis.base import VariableMeta
+
+meta = VariableMeta(
+    name="my_var",
+    axis_names=("particle",),
+    description="Example variable",
+)
+
+def build(cfg=None):
+    obj = type("Var", (), {})()
+    obj.meta = meta
+    return obj
+```
+
+## Recommended tests
+
+- Builder returns variable object with `meta`.
+- Describe API returns expected metadata.
+- Variable can be built through `build_variable(...)`.
+
+## What not to do / deferred work
+
+- Do not introduce a new formal metadata schema in this PR.
+- Keep analysis changes focused on extension discoverability and tests.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,35 @@
+# Extending part2pop
+
+## Purpose
+
+- Practical extension guide for contributors.
+- Companion to:
+  - `docs/roadmap.md`
+  - `docs/architecture.md`
+  - `docs/decisions/0001-builder-registry-contract.md`
+  - `docs/decisions/0002-builder-categories-and-deferred-observation-model-work.md`
+
+## Extension areas
+
+- Population builders: `docs/population_builders.md`
+- Analysis variables: `docs/analysis_variables.md`
+- Optical morphologies: `docs/optics.md`
+- Freezing parameterizations: `docs/freezing.md`
+- Visualization plotters: `docs/visualization.md`
+- Species and registry: `docs/species.md`
+
+## Core extension rules
+
+- Keep public APIs stable.
+- Prefer decorator registration in factory modules.
+- Keep fallback `module.build(...)` compatibility.
+- Add tests for every new extension.
+- Keep extension files small and focused.
+
+## For AI coding assistants
+
+- Keep PRs focused on one subsystem.
+- Add tests for every new extension.
+- Do not change public APIs without documenting it.
+- Prefer small registered factory files.
+- Do not add generated artifacts, local environment files, private scripts, or build metadata.

--- a/docs/freezing.md
+++ b/docs/freezing.md
@@ -1,0 +1,51 @@
+# Freezing
+
+## What this module owns
+
+- Freezing parameterization builders for particle/population freezing diagnostics.
+
+## Public API entry points
+
+- `build_freezing_particle(base_particle, config)`
+- `build_freezing_population(base_population, config)`
+
+## List/describe registered components
+
+- `list_freezing_types()`
+- `describe_freezing_type(name)`
+
+## Naming note
+
+- Some legacy code paths still use the term `morphology` for freezing type selection.
+
+## How to add a new extension
+
+1. Add a module under `src/part2pop/freezing/factory/`.
+2. Implement `build(base_particle, config)`.
+3. Prefer `@register("name")` for registration.
+
+## Required file location and naming pattern
+
+- Location: `src/part2pop/freezing/factory/`
+- Pattern: one type per module, lowercase filename, no leading `_`.
+
+## Minimal code example
+
+```python
+from part2pop.freezing.factory.registry import register
+
+@register("my_freezing_type")
+def build(base_particle, config):
+    """Return a freezing wrapper/parameterization instance."""
+    return base_particle
+```
+
+## Recommended tests
+
+- `list_freezing_types()` includes new entry.
+- `describe_freezing_type("my_freezing_type")` returns metadata.
+- `build_freezing_particle(..., {"morphology": "my_freezing_type"})` works.
+
+## What not to do / deferred work
+
+- No freezing architecture overhaul in this PR.

--- a/docs/optics.md
+++ b/docs/optics.md
@@ -1,0 +1,47 @@
+# Optics
+
+## What this module owns
+
+- Optical morphologies and optical particle/population wrappers.
+
+## Public API entry points
+
+- `build_optical_particle(base_particle, config)`
+- `build_optical_population(base_population, config)`
+
+## List/describe registered components
+
+- `list_morphology_types()`
+- `describe_morphology_type(name)`
+
+## How to add a new extension
+
+1. Add a factory module in `src/part2pop/optics/factory/`.
+2. Provide callable `build(base_particle, config)`.
+3. Prefer `@register("name")`.
+
+## Required file location and naming pattern
+
+- Location: `src/part2pop/optics/factory/`
+- Pattern: one morphology per module, lowercase filename, no leading `_`.
+
+## Minimal code example
+
+```python
+from part2pop.optics.factory.registry import register
+
+@register("my_morphology")
+def build(base_particle, config):
+    """Return an optical particle wrapper."""
+    return base_particle
+```
+
+## Recommended tests
+
+- `list_morphology_types()` includes the new entry.
+- `describe_morphology_type("my_morphology")` returns metadata.
+- `build_optical_particle(..., {"type": "my_morphology"})` works.
+
+## What not to do / deferred work
+
+- No broad optics architecture refactor in this PR.

--- a/docs/population_builders.md
+++ b/docs/population_builders.md
@@ -1,0 +1,67 @@
+# Population Builders
+
+## What this module owns
+
+- Construction of `ParticlePopulation` from config dictionaries.
+- Discovery of population builder implementations under factory modules.
+
+## Public API entry points
+
+- `build_population(config)`
+- `PopulationBuilder(config).build()`
+
+## List/describe registered components
+
+- `list_population_types()`
+- `describe_population_type(name)`
+
+## Builder categories
+
+- Distribution builders (current Priority 1 baseline):
+  - `monodisperse`
+  - `binned_lognormals`
+  - `sampled_lognormals`
+- Observation-constrained builders (deeper refactor deferred to Priority 2):
+  - `EDX`
+  - `HISCALE`
+- Model-derived builders (cleanup deferred to Priority 2):
+  - `PartMC`
+  - `MAM4`
+
+## How to add a new extension
+
+1. Add a new factory file under:
+   - `src/part2pop/population/factory/<name>.py`
+2. Implement `build(config)` that returns a `ParticlePopulation`.
+3. Prefer decorator registration via `@register("<name>")`.
+4. Keep module-level `build(...)` available for fallback compatibility.
+
+## Required file location and naming pattern
+
+- Location: `src/part2pop/population/factory/`
+- Pattern: one builder per module, lowercase filename, no leading `_`.
+
+## Minimal code example
+
+```python
+from part2pop.population.factory.registry import register
+from part2pop.population.base import ParticlePopulation
+
+@register("my_population")
+def build(config):
+    """Build a ParticlePopulation from config."""
+    pop = ParticlePopulation(species=[], masses=[], num_concs=[], ids=[])
+    return pop
+```
+
+## Recommended tests
+
+- Factory discovery test: builder appears in `list_population_types()`.
+- Describe test: `describe_population_type("my_population")` returns metadata.
+- Builder test: `build_population({"type": "my_population", ...})` works.
+
+## What not to do / deferred work
+
+- Do not refactor EDX/HISCALE internals in this phase.
+- Do not refactor PartMC/MAM4 internals in this phase.
+- Do not introduce formal schema systems yet.

--- a/docs/species.md
+++ b/docs/species.md
@@ -1,0 +1,66 @@
+# Species
+
+## What this module owns
+
+- `AerosolSpecies` representation.
+- Runtime species registration.
+- File-backed fallback species retrieval.
+
+## Public API entry points
+
+- `register_species(species)`
+- `get_species(name, specdata_path, **modifications)`
+- `list_species()`
+- `describe_species(name)`
+- `extend_species(species)`
+
+## List/describe registered components
+
+- `list_species()` currently lists custom runtime-registered species only.
+- `describe_species(name)` supports:
+  - custom registered species
+  - default file-backed species (if found)
+
+## How to add a new extension
+
+1. Create an `AerosolSpecies` object.
+2. Register it with `register_species(...)`.
+3. Use it through builders or `get_species(...)`.
+
+## Required file location and naming pattern
+
+- Runtime registration: no file required.
+- Default file-backed species data source:
+  - `species_data/aero_data.dat` via package data loader.
+
+## Minimal code example
+
+```python
+from part2pop.species import AerosolSpecies, register_species, describe_species
+
+spec = AerosolSpecies(
+    name="MY_SPEC",
+    density=1500.0,
+    kappa=0.2,
+    molar_mass=100.0,
+    surface_tension=0.072,
+)
+register_species(spec)
+print(describe_species("MY_SPEC"))
+```
+
+## Recommended tests
+
+- Register/list round-trip.
+- Describe custom species.
+- Describe known default species.
+- Unknown species error behavior.
+
+## specdata_path notes
+
+- `get_species(..., specdata_path=...)` can point to an alternate species data folder.
+- If `specdata_path` is `None`, package default data is used.
+
+## What not to do / deferred work
+
+- Do not introduce a new species metadata schema in this phase.

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,0 +1,47 @@
+# Visualization
+
+## What this module owns
+
+- Plotter discovery and construction for visualization outputs.
+
+## Public API entry points
+
+- `build_plotter(type, config)`
+
+## List/describe registered components
+
+- `list_plotter_types()`
+- `describe_plotter_type(name)`
+
+## How to add a new extension
+
+1. Add a factory module under `src/part2pop/viz/factory/`.
+2. Provide `build(config)` for the plotter.
+3. Prefer `@register("name")` registration.
+
+## Required file location and naming pattern
+
+- Location: `src/part2pop/viz/factory/`
+- Pattern: one plotter per module, lowercase filename, no leading `_`.
+
+## Minimal code example
+
+```python
+from part2pop.viz.factory.registry import register
+
+@register("my_plotter")
+def build(config):
+    """Return a plotter instance."""
+    return object()
+```
+
+## Recommended tests
+
+- `list_plotter_types()` includes new entry.
+- `describe_plotter_type("my_plotter")` returns metadata.
+- `build_plotter("my_plotter", config)` constructs successfully.
+
+## What not to do / deferred work
+
+- Do not treat `viewer/metadata.py` as long-term metadata source of truth.
+- GUI metadata migration remains staged work.


### PR DESCRIPTION
## Summary

Add module-level extension documentation for humans, reviewers, and AI coding assistants.

## Changes

- Added extension guides for:
  - population builders
  - analysis variables
  - optics morphologies
  - freezing parameterizations
  - visualization plotters
  - species registry
- Added `docs/extending.md` as a general extension entry point
- Documents public APIs, list/describe helpers, file locations, minimal examples, and recommended tests
- Clearly marks EDX/HISCALE and MAM4/PartMC refactors as deferred work

## Scope

- Documentation only
- No source-code behavior changes
- No public API changes