### PR TITLE
test: characterize observation builders and clarify builder contract

### DIFF
--- a/docs/population_builders.md
+++ b/docs/population_builders.md
@@ -4,11 +4,18 @@
 
 - Construction of `ParticlePopulation` from config dictionaries.
 - Discovery of population builder implementations under factory modules.
+- Population builders live in `src/part2pop/population/factory/`.
 
 ## Public API entry points
 
 - `build_population(config)`
 - `PopulationBuilder(config).build()`
+
+## Builder contract
+
+- A population builder is a **registered callable**.
+- Signature: accepts `config` and returns `ParticlePopulation`.
+- `PopulationBuilder` is a dispatcher/facade, not a required superclass.
 
 ## List/describe registered components
 
@@ -40,6 +47,9 @@
 
 - Location: `src/part2pop/population/factory/`
 - Pattern: one builder per module, lowercase filename, no leading `_`.
+- Large builders may keep internal support code in:
+  - `src/part2pop/population/factory/helpers/`
+- `helpers/` is internal and is **not** a builder plugin location.
 
 ## Minimal code example
 

--- a/src/part2pop/population/builder.py
+++ b/src/part2pop/population/builder.py
@@ -22,8 +22,8 @@ class PopulationBuilder:
         if type_name not in types:
             available = ", ".join(sorted(types.keys())) or "<none>"
             raise ValueError(f"Unknown population type: {type_name}. Available types: {available}")
-        cls = types[type_name]
-        return cls(self.config)
+        builder_fn = types[type_name]
+        return builder_fn(self.config)
 
 
 def build_population(config):

--- a/src/part2pop/population/factory/registry.py
+++ b/src/part2pop/population/factory/registry.py
@@ -53,7 +53,7 @@ def discover_population_types():
     types_pkg = __package__
     types_path = os.path.dirname(__file__)
     for _, module_name, _ in pkgutil.iter_modules([types_path]):
-        if module_name in {"registry", "__init__"} or module_name.startswith("_"):
+        if module_name in {"registry", "__init__", "helpers"} or module_name.startswith("_"):
             continue
         try:
             module = importlib.import_module(f"{types_pkg}.{module_name}")

--- a/tests/unit/population/factory/test_edx_observations.py
+++ b/tests/unit/population/factory/test_edx_observations.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from part2pop import ParticlePopulation, build_population
+
+
+def _write_edx_csv(tmp_path):
+    csv_path = tmp_path / "edx_small.csv"
+    # Keep columns aligned with current reader expectations:
+    # - element columns by direct names
+    # - one diameter column containing "diam"
+    # - one class/type column containing "class"
+    csv_path.write_text(
+        "diam_um,class,C,N,O,Na,Mg,Al,Si,P,S,Cl,K,Ca,Mn,Fe,Zn\n"
+        # biological row tuned to current mapping logic:
+        # - sums to 1.0
+        # - keeps Al/Si near zero so OIN contribution stays small
+        # - leaves substantial C/N/O/P/S pool for biological fraction
+        "0.5,biological,0.35,0.12,0.33,0.04,0.04,0.00,0.00,0.04,0.04,0.04,0.00,0.00,0.00,0.00,0.00\n"
+        "",
+        encoding="utf-8",
+    )
+    return csv_path
+
+
+def test_edx_observations_smoke_build_population(tmp_path):
+    edx_csv = _write_edx_csv(tmp_path)
+    cfg = {
+        "type": "edx_observations",
+        "edx_file": str(edx_csv),
+    }
+
+    pop = build_population(cfg)
+    assert isinstance(pop, ParticlePopulation)
+
+    # Characterize current behavior only
+    assert hasattr(pop, "classes")
+    assert len(pop.classes) == len(pop.ids)
+    assert len(pop.ids) == 1
+    assert len(pop.classes) == 1
+
+    # Number concentrations and diameters should be positive/plausible
+    assert np.all(pop.num_concs > 0)
+    d = pop.get_particle_var("Ddry")
+    assert np.all(np.isfinite(d))
+    assert np.all(d > 0)

--- a/tests/unit/population/factory/test_hiscale_observations.py
+++ b/tests/unit/population/factory/test_hiscale_observations.py
@@ -1020,6 +1020,24 @@ def test_build_input_validation_branches_and_preferred_matching(monkeypatch, tmp
     with pytest.raises(KeyError, match="missing required config keys"):
         hiscale.build({})
 
+    # Required key characterization checks (explicitly verify each required input)
+    required_keys = ["aimms_file", "splat_file", "ams_file", "z", "dz", "splat_species", "mass_thresholds"]
+    complete = {
+        "type": "hiscale_observations",
+        "aimms_file": "a.txt",
+        "splat_file": "s.txt",
+        "ams_file": "m.txt",
+        "z": 100.0,
+        "dz": 2.0,
+        "splat_species": {"BC": ["BC"]},
+        "mass_thresholds": {"BC": ((0.1, 0.2, 0.05), ["BC"])},
+    }
+    for rk in required_keys:
+        cfg_missing = dict(complete)
+        cfg_missing.pop(rk)
+        with pytest.raises(KeyError, match="missing required config keys"):
+            hiscale.build(cfg_missing)
+
     base_cfg = {
         "type": "hiscale_observations",
         "aimms_file": "a.txt",

--- a/tests/unit/population/factory/test_registry.py
+++ b/tests/unit/population/factory/test_registry.py
@@ -90,6 +90,7 @@ def test_discover_population_types_skips_private_and_broken_modules(monkeypatch)
         SimpleNamespace(
             iter_modules=lambda paths: [
                 (None, "_private", False),
+                (None, "helpers", True),
                 (None, "registry", False),
                 (None, "broken", False),
                 (None, "good", False),
@@ -113,6 +114,7 @@ def test_discover_population_types_skips_private_and_broken_modules(monkeypatch)
     assert "good" in discovered
     assert "broken" not in discovered
     assert "_private" not in discovered
+    assert "helpers" not in discovered
 
 
 def test_list_population_types_sorted(monkeypatch):
@@ -146,3 +148,18 @@ def test_describe_population_type_unknown(monkeypatch):
     monkeypatch.setattr(factory_registry, "discover_population_types", lambda: {}, raising=False)
     with pytest.raises(ValueError, match="Unknown population type"):
         factory_registry.describe_population_type("missing")
+
+
+def test_list_population_types_includes_observation_builders():
+    types = factory_registry.list_population_types()
+    assert "edx_observations" in types
+    assert "hiscale_observations" in types
+
+
+def test_describe_population_type_for_observation_builders():
+    edx = factory_registry.describe_population_type("edx_observations")
+    hiscale = factory_registry.describe_population_type("hiscale_observations")
+    assert edx["name"] == "edx_observations"
+    assert hiscale["name"] == "hiscale_observations"
+    assert edx["module"] is not None
+    assert hiscale["module"] is not None


### PR DESCRIPTION
## Summary

Establishes a Phase 2 baseline for observation-constrained population builders and clarifies the population-builder contract.

## Changes

* Added characterization tests for:

  * `edx_observations` (synthetic smoke test)
  * `hiscale_observations` (required-config validation)
* Verified registry integration:

  * `list_population_types()` includes observation builders
  * `describe_population_type(...)` works for both
* Updated `docs/population_builders.md`:

  * Clarifies that population builders are **registered callables** in `population/factory/`
  * Clarifies that `PopulationBuilder` is a dispatcher/facade, not a required superclass
* Minor internal cleanup:

  * Renamed local variable `cls` → `builder_fn` in builder dispatcher
  * Ensured registry discovery skips internal/helper modules

## Scope

* No refactor of EDX or HISCALE internals
* No changes to PartMC or MAM4 builders
* No public API changes
* No JOSS paper edits

## Purpose

This PR locks in current behavior for observation builders and makes the extension boundary clearer before proceeding with Phase 2 structural work (shared assembly helpers and builder decomposition).
