### PR TITLE
Refactor EDX population assembly

### DIFF
--- a/src/part2pop/population/factory/edx_observations.py
+++ b/src/part2pop/population/factory/edx_observations.py
@@ -7,11 +7,11 @@ following columns:
 """
 
 from .registry import register
+from .helpers.assembly import assemble_population_from_mass_fractions
 from typing import Any, Dict
 from part2pop.population.base import ParticlePopulation
 import pandas as pd
 import numpy as np
-from part2pop.population import build_population
 import warnings
 
 class ElementMasses:
@@ -67,19 +67,21 @@ def build(config: Dict[str, Any]) -> ParticlePopulation:
         else:
             aero_spec_masses[ii] = sample_particle(aero_spec_names, MassFracs, raw_population.elements)
 
-    # make the particle population from the species mass fractions
+    # make the particle population from explicit per-particle rows
     new_aero_spec_names = [aero_spec_names.copy() for _ in range(len(aero_spec_masses))]
-    species_modifications = config.get("species_modifications",{})
-    population_cfg = {
-        "type": "monodisperse",
-        "N": np.ones(len(aero_spec_masses)),
-        "D": raw_population.D,
-        "aero_spec_names": new_aero_spec_names,
-        "aero_spec_fracs": aero_spec_masses,
-        "species_modifications": species_modifications
-    }
-    particle_population = build_population(population_cfg)
-    particle_population.classes=np.array(particle_classes)
+    species_modifications = config.get("species_modifications", {})
+    D_is_wet = config.get("D_is_wet", False)
+    specdata_path = config.get("specdata_path")
+    particle_population = assemble_population_from_mass_fractions(
+        diameters=raw_population.D,
+        number_concentrations=np.ones(len(aero_spec_masses)),
+        species_names=new_aero_spec_names,
+        mass_fractions=aero_spec_masses,
+        classes=particle_classes,
+        species_modifications=species_modifications,
+        D_is_wet=D_is_wet,
+        specdata_path=specdata_path,
+    )
     return particle_population
 
 

--- a/tests/unit/population/factory/test_edx_observations.py
+++ b/tests/unit/population/factory/test_edx_observations.py
@@ -1,6 +1,10 @@
 import numpy as np
 
 from part2pop import ParticlePopulation, build_population
+from part2pop.population.factory.helpers.assembly import (
+    assemble_population_from_mass_fractions as real_assemble_population_from_mass_fractions,
+)
+from part2pop.population.factory import edx_observations
 
 
 def _write_edx_csv(tmp_path):
@@ -43,3 +47,43 @@ def test_edx_observations_smoke_build_population(tmp_path):
     d = pop.get_particle_var("Ddry")
     assert np.all(np.isfinite(d))
     assert np.all(d > 0)
+
+
+def test_edx_observations_calls_assembly_helper_directly(tmp_path, monkeypatch):
+    edx_csv = _write_edx_csv(tmp_path)
+    cfg = {
+        "type": "edx_observations",
+        "edx_file": str(edx_csv),
+    }
+
+    captured = {"count": 0, "kwargs": None}
+
+    def _capture_and_build(**kwargs):
+        captured["count"] += 1
+        captured["kwargs"] = kwargs
+        return real_assemble_population_from_mass_fractions(**kwargs)
+
+    monkeypatch.setattr(
+        edx_observations,
+        "assemble_population_from_mass_fractions",
+        _capture_and_build,
+    )
+
+    pop = build_population(cfg)
+
+    assert captured["count"] == 1
+    assert isinstance(pop, ParticlePopulation)
+    assert pop.spec_masses.ndim == 2
+
+    kwargs = captured["kwargs"]
+    diameters = kwargs["diameters"]
+    number_concentrations = kwargs["number_concentrations"]
+    species_names = kwargs["species_names"]
+    mass_fractions = kwargs["mass_fractions"]
+    classes = kwargs["classes"]
+
+    assert len(diameters) == len(number_concentrations)
+    assert len(species_names) == len(diameters)
+    assert len(mass_fractions) == len(diameters)
+    assert classes is not None
+    assert len(classes) == len(diameters)


### PR DESCRIPTION
## Summary

Refactors the EDX observation builder to use the shared explicit-row population assembly helper directly.

Changes:
- Route EDX explicit particle rows through `assemble_population_from_mass_fractions(...)`.
- Remove the internal `build_population({"type": "monodisperse", ...})` dispatch hop.
- Preserve existing EDX parsing, sampling, species semantics, class handling, and public config API.
- Add a focused regression test verifying EDX calls the assembly helper directly and returns a real `ParticlePopulation`.

## Scope

This PR intentionally does not clean up the broader EDX reconstruction logic. The builder still contains pre-existing element-to-species assumptions and class-specific reconstruction code. Those will be addressed in follow-up cleanup issues.

## Validation

- `pytest tests/unit/population/factory/test_edx_observations.py`
- `pytest tests/unit/population/factory/helpers/test_assembly.py`
- `pytest tests/unit/population/factory`
- `pytest`