### PR TITLE
Update ADRs to reflect Phase 2 progress and builder maturity

### DIFF
--- a/docs/decisions/0001-builder-registry-contract.md
+++ b/docs/decisions/0001-builder-registry-contract.md
@@ -16,6 +16,7 @@ Accepted (JOSS-facing baseline)
 - Decorator-based registration is preferred.
 - Module-level `build(...)` fallback may remain for backward compatibility.
 - Registries should evolve to expose `list_*` and `describe_*` functions.
+- Population builders now commonly terminate in a shared population assembly helper for explicit particle rows.
 - Public builder APIs remain stable:
   - `build_population(config)`
   - `build_variable(...)`

--- a/docs/decisions/0002-builder-categories-and-deferred-observation-model-work.md
+++ b/docs/decisions/0002-builder-categories-and-deferred-observation-model-work.md
@@ -21,6 +21,9 @@ Accepted (JOSS-facing scope control)
 
 - `EDX`
 - `HISCALE`
+- Current implementation status:
+  - both now terminate in shared `assemble_population_from_mass_fractions(...)`
+  - both are functional, but internal cleanup/reorganization is still pending
 - Future direction:
   - introduce explicit `reconstruction_strategy`
   - use reader → reconstruction strategy → population assembly flow

--- a/docs/decisions/0003-gui-metadata-source-of-truth.md
+++ b/docs/decisions/0003-gui-metadata-source-of-truth.md
@@ -15,6 +15,7 @@ Accepted (directional, post-Priority-1 execution)
 - `viewer/metadata.py` should not remain the long-term source of truth.
 - Priority 1 does **not** require completing full GUI migration.
 - Priority 1 should document this direction and prepare registry metadata contracts.
+- Current registry metadata APIs are stable enough to support future GUI metadata migration work.
 
 ## Consequences
 

--- a/docs/decisions/0004-joss-release-scope.md
+++ b/docs/decisions/0004-joss-release-scope.md
@@ -17,8 +17,17 @@ Accepted (release-defining)
   - hardened registry/discovery behavior
   - strong public API and registry tests
 - JOSS release does **not** require completing every future refactor.
-- Deeper refactors for `EDX` / `HISCALE` and `PartMC` / `MAM4` are deferred to Priority 2 unless time allows.
+- Observation builders (`EDX`, `HISCALE`) are currently functional but not fully internally reorganized.
+- Partial Phase 2 progress is complete for observation assembly: `EDX` and `HISCALE` now terminate in shared `assemble_population_from_mass_fractions(...)` rather than routing explicit rows through `monodisperse`.
+- Deeper internal cleanup for `EDX` / `HISCALE`, and broader refactors for `PartMC` / `MAM4`, remain deferred to Priority 2 unless time allows.
 - JOSS paper may describe intended extension architecture without claiming every builder has already been internally reorganized.
+
+Builder maturity (current):
+- Distribution builders: stable/reference.
+- Observation builders: functional, undergoing cleanup.
+- Model builders: functional, deferred cleanup.
+
+All builders produce valid ParticlePopulation objects and are covered by tests, even where internal organization is still evolving.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

Updates ADRs 0001–0004 to reflect current implementation status after Phase 2 observation-builder progress.

Changes:
- Clarify that EDX and HISCALE now use the shared assembly helper
- Document that observation builders are functional but not fully reorganized
- Add builder maturity levels for distribution, observation, and model builders
- Align JOSS release-scope ADR with current implementation

## Notes

- Documentation-only change
- No API changes
- No source-code changes