### PR TITLE
Add species name resolution layer

### DIFF
--- a/src/part2pop/species/__init__.py
+++ b/src/part2pop/species/__init__.py
@@ -1,4 +1,5 @@
 from .base import AerosolSpecies
+from .resolution import resolve_species_name, resolve_species_names
 from .registry import (
     get_species,
     register_species,

--- a/src/part2pop/species/registry.py
+++ b/src/part2pop/species/registry.py
@@ -7,6 +7,7 @@ reads `datasets/species_data/aero_data.dat` for default species.
 
 import copy
 from .base import AerosolSpecies
+from .resolution import resolve_species_name
 # from ..data import species_open
 from ..data import open_dataset
 import os
@@ -21,19 +22,31 @@ class AerosolSpeciesRegistry:
         """Add or update a species in the registry."""
         self._custom[species.name.upper()] = copy.deepcopy(species)
 
-    def get(self, name: str, specdata_path: str, **modifications) -> AerosolSpecies:
+    def get(self, name: str, specdata_path: str | None, **modifications) -> AerosolSpecies:
         """Get a species from the registry, optionally with modifications.
         Falls back to data file lookup if not registered.
         """
-        key = name.upper()
+        key = str(name).upper()
         if key in self._custom:
             base = copy.deepcopy(self._custom[key])
             for k, v in modifications.items():
                 setattr(base, k, v)
             return base
+
+        resolved_name = resolve_species_name(name)
+        resolved_key = resolved_name.upper()
+        if resolved_key in self._custom:
+            base = copy.deepcopy(self._custom[resolved_key])
+            for k, v in modifications.items():
+                setattr(base, k, v)
+            return base
         
         # fallback to retrieve_one_species (file-based) if not registered
-        return retrieve_one_species(name, specdata_path=specdata_path, spec_modifications=modifications)
+        return retrieve_one_species(
+            resolved_name,
+            specdata_path=specdata_path,
+            spec_modifications=modifications,
+        )
 
     def extend(self, species: AerosolSpecies):
         """Alias for register for API clarity."""
@@ -49,7 +62,7 @@ _registry = AerosolSpeciesRegistry()
 def register_species(species: AerosolSpecies):
     _registry.register(species)
 
-def get_species(name: str, specdata_path: str, **modifications) -> AerosolSpecies:
+def get_species(name: str, specdata_path: str | None, **modifications) -> AerosolSpecies:
     return _registry.get(name, specdata_path, **modifications)
 
 def list_species():
@@ -57,7 +70,7 @@ def list_species():
 
 
 def describe_species(name: str, specdata_path: str | None = None):
-    key = name.upper()
+    key = str(name).upper()
     if key in _registry._custom:
         sp = _registry._custom[key]
         return {
@@ -73,8 +86,29 @@ def describe_species(name: str, specdata_path: str | None = None):
             },
         }
 
+    resolved_name = resolve_species_name(name)
+    resolved_key = resolved_name.upper()
+    if resolved_key in _registry._custom:
+        sp = _registry._custom[resolved_key]
+        return {
+            "name": sp.name,
+            "module": sp.__class__.__module__,
+            "type": sp.__class__.__name__,
+            "description": (sp.__class__.__doc__ or "").strip() or None,
+            "defaults": {
+                "density": getattr(sp, "density", None),
+                "kappa": getattr(sp, "kappa", None),
+                "molar_mass": getattr(sp, "molar_mass", None),
+                "surface_tension": getattr(sp, "surface_tension", None),
+            },
+        }
+
     try:
-        sp = retrieve_one_species(name, specdata_path=specdata_path, spec_modifications={})
+        sp = retrieve_one_species(
+            resolved_name,
+            specdata_path=specdata_path,
+            spec_modifications={},
+        )
     except ValueError as exc:
         available = ", ".join(sorted(list_species())) or "<none>"
         raise ValueError(

--- a/src/part2pop/species/registry.py
+++ b/src/part2pop/species/registry.py
@@ -42,11 +42,18 @@ class AerosolSpeciesRegistry:
             return base
         
         # fallback to retrieve_one_species (file-based) if not registered
-        return retrieve_one_species(
-            resolved_name,
-            specdata_path=specdata_path,
-            spec_modifications=modifications,
-        )
+        try:
+            return retrieve_one_species(
+                resolved_name,
+                specdata_path=specdata_path,
+                spec_modifications=modifications,
+            )
+        except ValueError as exc:
+            if str(name) != resolved_name:
+                raise ValueError(
+                    f"Species lookup failed for {name!r} (resolved to {resolved_name!r}): {exc}"
+                ) from exc
+            raise
 
     def extend(self, species: AerosolSpecies):
         """Alias for register for API clarity."""

--- a/src/part2pop/species/resolution.py
+++ b/src/part2pop/species/resolution.py
@@ -6,7 +6,7 @@ without defining any species physical properties.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 import re
 
 
@@ -20,7 +20,7 @@ def _normalize_label(name: str) -> str:
     hyphens consistently.
     """
     text = str(name).strip().casefold()
-    text = _SEPARATOR_RE.sub(" ", text)
+    text = _SEPARATOR_RE.sub(" ", text).strip()
     return text
 
 
@@ -60,7 +60,7 @@ def resolve_species_name(name: str, aliases: Mapping[str, str] | None = None) ->
 
 
 def resolve_species_names(
-    names: list[str] | tuple[str, ...], aliases: Mapping[str, str] | None = None
+    names: Sequence[str], aliases: Mapping[str, str] | None = None
 ) -> list[str]:
     """Resolve a sequence of source labels in order."""
     return [resolve_species_name(name, aliases=aliases) for name in names]

--- a/src/part2pop/species/resolution.py
+++ b/src/part2pop/species/resolution.py
@@ -1,0 +1,66 @@
+"""Species-name resolution helpers.
+
+This module maps source/instrument labels to canonical part2pop species names
+without defining any species physical properties.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import re
+
+
+_SEPARATOR_RE = re.compile(r"[\s_\-]+")
+
+
+def _normalize_label(name: str) -> str:
+    """Normalize a species label for alias lookup.
+
+    Normalization is case-insensitive and treats spaces, underscores, and
+    hyphens consistently.
+    """
+    text = str(name).strip().casefold()
+    text = _SEPARATOR_RE.sub(" ", text)
+    return text
+
+
+_DEFAULT_ALIASES: dict[str, str] = {
+    _normalize_label("dust"): "OIN",
+    _normalize_label("soot"): "BC",
+    _normalize_label("black carbon"): "BC",
+    _normalize_label("org"): "OC",
+    _normalize_label("poa"): "OC",
+}
+
+
+def resolve_species_name(name: str, aliases: Mapping[str, str] | None = None) -> str:
+    """Resolve one source label to a canonical species name.
+
+    Parameters
+    ----------
+    name
+        Input species label from a source or builder config.
+    aliases
+        Optional call-scoped aliases that extend/override defaults.
+
+    Returns
+    -------
+    str
+        Canonical species name if matched; otherwise the stripped original
+        name (pass-through behavior).
+    """
+    stripped = str(name).strip()
+    merged = dict(_DEFAULT_ALIASES)
+
+    if aliases:
+        for alias_key, canonical in aliases.items():
+            merged[_normalize_label(alias_key)] = str(canonical)
+
+    return merged.get(_normalize_label(stripped), stripped)
+
+
+def resolve_species_names(
+    names: list[str] | tuple[str, ...], aliases: Mapping[str, str] | None = None
+) -> list[str]:
+    """Resolve a sequence of source labels in order."""
+    return [resolve_species_name(name, aliases=aliases) for name in names]

--- a/tests/unit/species/test_registry.py
+++ b/tests/unit/species/test_registry.py
@@ -140,3 +140,51 @@ def test_get_species_unknown_alias_fails_clearly():
         assert "not found" in message or "Unknown species" in message
     else:
         raise AssertionError("Expected ValueError for unknown species")
+
+
+def test_registry_get_resolves_alias_to_custom_registered_species():
+    from part2pop.species.registry import AerosolSpeciesRegistry
+
+    registry = AerosolSpeciesRegistry()
+    registry.register(
+        AerosolSpecies(
+            name="OIN",
+            density=999.0,
+            kappa=0.99,
+            molar_mass=99.0,
+            surface_tension=0.09,
+        )
+    )
+
+    resolved = registry.get("dust", None, kappa=0.5)
+
+    assert resolved.name == "OIN"
+    assert resolved.density == 999.0
+    assert resolved.kappa == 0.5
+    assert resolved.molar_mass == 99.0
+    assert resolved.surface_tension == 0.09
+
+
+def test_describe_species_resolves_alias_to_custom_registered_species(monkeypatch):
+    import part2pop.species.registry as species_registry
+
+    registry = species_registry.AerosolSpeciesRegistry()
+    registry.register(
+        AerosolSpecies(
+            name="OC",
+            density=888.0,
+            kappa=0.88,
+            molar_mass=88.0,
+            surface_tension=0.08,
+        )
+    )
+    monkeypatch.setattr(species_registry, "_registry", registry)
+
+    info = species_registry.describe_species("POA")
+
+    assert info["name"] == "OC"
+    assert info["type"] == "AerosolSpecies"
+    assert info["defaults"]["density"] == 888.0
+    assert info["defaults"]["kappa"] == 0.88
+    assert info["defaults"]["molar_mass"] == 88.0
+    assert info["defaults"]["surface_tension"] == 0.08

--- a/tests/unit/species/test_registry.py
+++ b/tests/unit/species/test_registry.py
@@ -30,6 +30,28 @@ def test_get_species_loads_default_data_case_insensitive():
     assert so4_upper.molar_mass == so4_lower.molar_mass
 
 
+def test_get_species_resolves_dust_alias_to_oin():
+    specdata_path = None
+    dust = get_species("Dust", specdata_path)
+
+    assert isinstance(dust, AerosolSpecies)
+    assert dust.name.upper() == "OIN"
+    assert dust.density is not None
+    assert dust.kappa is not None
+    assert dust.molar_mass is not None
+
+
+def test_get_species_resolves_soot_alias_to_bc():
+    specdata_path = None
+    soot = get_species("soot", specdata_path)
+
+    assert isinstance(soot, AerosolSpecies)
+    assert soot.name.upper() == "BC"
+    assert soot.density is not None
+    assert soot.kappa is not None
+    assert soot.molar_mass is not None
+
+
 def test_register_species_and_list_species_round_trip():
     """Register a custom species and ensure it can be retrieved and listed."""
     
@@ -105,3 +127,16 @@ def test_describe_species_custom_specdata_path():
     assert info["name"].upper() == "CUSTSPEC"
     assert info["defaults"]["density"] == 1234.0
     assert info["defaults"]["kappa"] == 0.42
+
+
+def test_get_species_unknown_alias_fails_clearly():
+    missing = "definitely_unknown_species_label"
+
+    try:
+        get_species(missing, None)
+    except ValueError as exc:
+        message = str(exc)
+        assert missing in message
+        assert "not found" in message or "Unknown species" in message
+    else:
+        raise AssertionError("Expected ValueError for unknown species")

--- a/tests/unit/species/test_registry.py
+++ b/tests/unit/species/test_registry.py
@@ -3,6 +3,8 @@
 import os
 import tempfile
 
+import pytest
+
 from part2pop.species.base import AerosolSpecies
 from part2pop.species.registry import (
     get_species,
@@ -190,7 +192,7 @@ def test_describe_species_resolves_alias_to_custom_registered_species(monkeypatc
     assert info["defaults"]["surface_tension"] == 0.08
 
 
-def test_get_species_alias_resolved_name_missing_from_custom_specdata():
+def test_missing_species_error_includes_alias_and_resolved_name():
     """Error message must include both the original alias and the resolved canonical name."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Minimal dataset that does NOT contain OIN (the target of 'dust')
@@ -199,13 +201,7 @@ def test_get_species_alias_resolved_name_missing_from_custom_specdata():
             fh.write("# minimal dataset without OIN\n")
             fh.write("SO4  1840.0  3  96d-3  1.2\n")
 
-        try:
+        with pytest.raises(ValueError, match="dust") as exc_info:
             get_species("dust", tmpdir)
-        except ValueError as exc:
-            message = str(exc)
-            assert "dust" in message
-            assert "OIN" in message
-        else:
-            raise AssertionError(
-                "Expected ValueError when resolved species is missing from custom specdata_path"
-            )
+
+    assert "OIN" in str(exc_info.value)

--- a/tests/unit/species/test_registry.py
+++ b/tests/unit/species/test_registry.py
@@ -188,3 +188,24 @@ def test_describe_species_resolves_alias_to_custom_registered_species(monkeypatc
     assert info["defaults"]["kappa"] == 0.88
     assert info["defaults"]["molar_mass"] == 88.0
     assert info["defaults"]["surface_tension"] == 0.08
+
+
+def test_get_species_alias_resolved_name_missing_from_custom_specdata():
+    """Error message must include both the original alias and the resolved canonical name."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Minimal dataset that does NOT contain OIN (the target of 'dust')
+        dat_path = os.path.join(tmpdir, "aero_data.dat")
+        with open(dat_path, "w") as fh:
+            fh.write("# minimal dataset without OIN\n")
+            fh.write("SO4  1840.0  3  96d-3  1.2\n")
+
+        try:
+            get_species("dust", tmpdir)
+        except ValueError as exc:
+            message = str(exc)
+            assert "dust" in message
+            assert "OIN" in message
+        else:
+            raise AssertionError(
+                "Expected ValueError when resolved species is missing from custom specdata_path"
+            )

--- a/tests/unit/species/test_resolution.py
+++ b/tests/unit/species/test_resolution.py
@@ -1,0 +1,38 @@
+from part2pop.species import resolve_species_name, resolve_species_names
+
+
+def test_default_aliases_resolve_expected_labels():
+    assert resolve_species_name("dust") == "OIN"
+    assert resolve_species_name("Dust") == "OIN"
+    assert resolve_species_name("soot") == "BC"
+    assert resolve_species_name("black carbon") == "BC"
+    assert resolve_species_name("Org") == "OC"
+    assert resolve_species_name("POA") == "OC"
+
+
+def test_alias_normalization_handles_underscores_and_hyphens():
+    assert resolve_species_name("black_carbon") == "BC"
+    assert resolve_species_name("BLACK-CARBON") == "BC"
+
+
+def test_canonical_names_pass_through_when_not_aliased():
+    assert resolve_species_name("SO4") == "SO4"
+    assert resolve_species_name("OC") == "OC"
+    assert resolve_species_name("BC") == "BC"
+
+
+def test_user_aliases_extend_defaults_for_single_call():
+    aliases = {"foo dust": "OIN"}
+    assert resolve_species_name("foo_dust", aliases=aliases) == "OIN"
+    # defaults still apply while extended
+    assert resolve_species_name("dust", aliases=aliases) == "OIN"
+
+
+def test_user_aliases_override_defaults_for_single_call():
+    aliases = {"dust": "OC"}
+    assert resolve_species_name("dust", aliases=aliases) == "OC"
+
+
+def test_resolve_species_names_resolves_sequence_in_order():
+    resolved = resolve_species_names(["Dust", "soot", "SO4", "black_carbon"])
+    assert resolved == ["OIN", "BC", "SO4", "BC"]


### PR DESCRIPTION
## Summary

Adds a small species-name resolution layer for source/instrument labels that do not directly match canonical part2pop species names.

Implemented:
- `src/part2pop/species/resolution.py`
- `resolve_species_name(name, aliases=None)`
- `resolve_species_names(names, aliases=None)`
- default aliases:
  - `dust` / `Dust` -> `OIN`
  - `soot` / `black carbon` -> `BC`
  - `Org` / `POA` -> `OC`
- case-insensitive alias matching
- normalization across spaces, underscores, and hyphens
- per-call user aliases that extend or override defaults
- registry integration so `get_species(...)` accepts resolved aliases

## Scope

This PR is intentionally species-only.

Not changed:
- population builders
- EDX/HISCALE builders
- species physical properties
- `aero_data.dat`
- public builder APIs
- nested `tests/tests` tree

## Tests

```bash
python -m pytest tests/unit/species/test_resolution.py tests/unit/species/test_registry.py
python -m pytest tests/unit/species
python -m pytest