### PR TITLE
refactor(population): clarify PartMC row preparation

### DIFF
--- a/src/part2pop/population/factory/partmc.py
+++ b/src/part2pop/population/factory/partmc.py
@@ -15,6 +15,41 @@ from pathlib import Path
 from .registry import register
 
 
+def _load_particle_rows(currnc):
+    aero_spec_names = currnc.variables["aero_species"].names.split(",")
+    spec_masses = np.array(currnc.variables["aero_particle_mass"][:])
+    part_ids = np.array([one_id for one_id in currnc.variables["aero_id"][:]], dtype=int)
+
+    if "aero_num_conc" in currnc.variables.keys():
+        num_concs = currnc.variables["aero_num_conc"][:]
+    else:
+        num_concs = 1.0 / currnc.variables["aero_comp_vol"][:]
+
+    return aero_spec_names, spec_masses, part_ids, num_concs
+
+
+def _select_particle_indices(part_ids, n_particles):
+    if n_particles is None:
+        return np.arange(len(part_ids))
+    if n_particles <= len(part_ids):
+        return np.random.choice(np.arange(len(part_ids)), size=n_particles, replace=False)
+    raise IndexError("n_particles > len(part_ids)")
+
+
+def _resolve_target_total_number(num_concs, N_tot):
+    if N_tot is None:
+        return np.sum(num_concs)
+    return N_tot
+
+
+def _rescale_selected_number_concentrations(num_concs, idx, N_tot):
+    return num_concs[idx] * N_tot / np.sum(num_concs[idx])
+
+
+def _extract_gas_mixing_ratios(currnc):
+    return np.array(currnc.variables["gas_mixing_ratio"][:])
+
+
 @register("partmc") # only registers if netCDF4 is available
 def build(config):
     partmc_dir = Path(config['partmc_dir'])
@@ -30,29 +65,16 @@ def build(config):
     partmc_filepath = get_ncfile(partmc_dir / 'out', timestep, repeat)
     currnc = netCDF4.Dataset(partmc_filepath)
 
-    aero_spec_names = currnc.variables['aero_species'].names.split(',')
+    aero_spec_names, spec_masses, part_ids, num_concs = _load_particle_rows(currnc)
     # Get AerosolSpecies objects with modifications if any
     species_list = tuple(
         get_species(name, specdata_path, **species_modifications.get(name, {}))
         for name in aero_spec_names
     )
-    spec_masses = np.array(currnc.variables['aero_particle_mass'][:])
-    part_ids = np.array([one_id for one_id in currnc.variables['aero_id'][:]], dtype=int)
 
-    if 'aero_num_conc' in currnc.variables.keys():
-        num_concs = currnc.variables['aero_num_conc'][:]
-    else:
-        num_concs = 1. / currnc.variables['aero_comp_vol'][:]
-
-    if N_tot is None:
-        N_tot = np.sum(num_concs)
-
-    if n_particles is None:
-        idx = np.arange(len(part_ids))
-    elif n_particles <= len(part_ids):
-        idx = np.random.choice(np.arange(len(part_ids)), size=n_particles, replace=False)
-    else:
-        raise IndexError('n_particles > len(part_ids)')
+    N_tot = _resolve_target_total_number(num_concs, N_tot)
+    idx = _select_particle_indices(part_ids, n_particles)
+    num_concs_selected = _rescale_selected_number_concentrations(num_concs, idx, N_tot)
 
     partmc_population = ParticlePopulation(
         species=species_list,
@@ -67,12 +89,11 @@ def build(config):
             spec_masses[:, ii],
             species_modifications=species_modifications,
         )
-        partmc_population.set_particle(
-            particle, part_ids[ii], num_concs[ii] * N_tot / np.sum(num_concs[idx]), suppress_warning=suppress_warning
-        )
+        selected_position = np.where(idx == ii)[0][0]
+        partmc_population.set_particle(particle, part_ids[ii], num_concs_selected[selected_position], suppress_warning=suppress_warning)
 
     if add_mixing_ratios:
-        gas_mixing_ratios = np.array(currnc.variables['gas_mixing_ratio'][:])
+        gas_mixing_ratios = _extract_gas_mixing_ratios(currnc)
         partmc_population.gas_mixing_ratios = gas_mixing_ratios
     return partmc_population
 

--- a/tests/unit/population/factory/test_partmc.py
+++ b/tests/unit/population/factory/test_partmc.py
@@ -11,6 +11,10 @@ try:
         build as build_partmc,
         map_camp_specs,
         get_ncfile,
+        _load_particle_rows,
+        _select_particle_indices,
+        _resolve_target_total_number,
+        _rescale_selected_number_concentrations,
     )
     HAS_NETCDF4 = True
 except Exception:
@@ -18,6 +22,10 @@ except Exception:
     build_partmc = None
     map_camp_specs = None
     get_ncfile = None
+    _load_particle_rows = None
+    _select_particle_indices = None
+    _resolve_target_total_number = None
+    _rescale_selected_number_concentrations = None
     HAS_NETCDF4 = False
 
 pytestmark = pytest.mark.skipif(
@@ -202,3 +210,86 @@ def test_partmc_build_adds_mixing_ratios(tmp_path):
         }
     )
     assert hasattr(pop, "gas_mixing_ratios")
+
+
+def test_load_particle_rows_uses_aero_num_conc_when_present(tmp_path):
+    _, fname = _create_partmc_nc(tmp_path, n_particles=3)
+    with netCDF4.Dataset(str(fname), "a") as ds:
+        num_conc = ds.createVariable("aero_num_conc", "f8", ("particle",))
+        num_conc[:] = np.array([11.0, 13.0, 17.0])
+        ds.variables["aero_comp_vol"][:] = np.array([2.0, 4.0, 8.0])
+
+    with netCDF4.Dataset(str(fname), "r") as ds:
+        _, _, _, num_concs = _load_particle_rows(ds)
+
+    assert np.allclose(np.array(num_concs), np.array([11.0, 13.0, 17.0]))
+
+
+def test_load_particle_rows_falls_back_to_inverse_aero_comp_vol_when_num_conc_missing(tmp_path):
+    _, fname = _create_partmc_nc(tmp_path, n_particles=3)
+    with netCDF4.Dataset(str(fname), "a") as ds:
+        ds.variables["aero_comp_vol"][:] = np.array([2.0, 4.0, 8.0])
+
+    with netCDF4.Dataset(str(fname), "r") as ds:
+        _, _, _, num_concs = _load_particle_rows(ds)
+
+    assert np.allclose(np.array(num_concs), np.array([0.5, 0.25, 0.125]))
+
+
+def test_select_particle_indices_none_returns_full_arange():
+    part_ids = np.array([10, 20, 30, 40], dtype=int)
+    idx = _select_particle_indices(part_ids, n_particles=None)
+    assert np.array_equal(idx, np.arange(len(part_ids)))
+
+
+def test_select_particle_indices_controlled_choice(monkeypatch):
+    part_ids = np.array([10, 20, 30, 40], dtype=int)
+    controlled = np.array([3, 1], dtype=int)
+
+    monkeypatch.setattr(
+        "part2pop.population.factory.partmc.np.random.choice",
+        lambda arr, size, replace: controlled,
+    )
+
+    idx = _select_particle_indices(part_ids, n_particles=2)
+    assert np.array_equal(idx, controlled)
+
+
+def test_resolve_target_total_number_defaults_to_sum():
+    num_concs = np.array([1.5, 2.5, 4.0])
+    resolved = _resolve_target_total_number(num_concs, N_tot=None)
+    assert np.isclose(resolved, np.sum(num_concs))
+
+
+def test_resolve_target_total_number_uses_explicit_value():
+    num_concs = np.array([1.5, 2.5, 4.0])
+    resolved = _resolve_target_total_number(num_concs, N_tot=123.0)
+    assert resolved == 123.0
+
+
+def test_rescale_selected_number_concentrations_preserves_selected_fractions_and_hits_target():
+    num_concs = np.array([2.0, 5.0, 3.0, 10.0])
+    idx = np.array([0, 2, 3], dtype=int)
+    N_tot_target = 60.0
+
+    rescaled = _rescale_selected_number_concentrations(num_concs, idx, N_tot_target)
+    selected = num_concs[idx]
+
+    assert np.isclose(np.sum(rescaled), N_tot_target)
+    assert np.isclose(rescaled[0] / rescaled[1], selected[0] / selected[1])
+    assert np.isclose(rescaled[1] / rescaled[2], selected[1] / selected[2])
+
+
+def test_partmc_build_without_mixing_ratios_leaves_attribute_unset(tmp_path):
+    partmc_dir, _ = _create_partmc_nc(tmp_path, n_particles=3)
+    pop = build_partmc(
+        {
+            "partmc_dir": str(tmp_path),
+            "timestep": 1,
+            "repeat": 1,
+            "N_tot": 1e6,
+            "n_particles": 2,
+            "add_mixing_ratios": False,
+        }
+    )
+    assert not hasattr(pop, "gas_mixing_ratios")


### PR DESCRIPTION
## Summary

Part of #43.

This PR performs a narrow PartMC-only cleanup by separating PartMC row/data preparation into private helper functions inside `population/factory/partmc.py`.

The builder remains self-contained in one factory file. This preserves the simple extension pattern where straightforward builders can live entirely in `population/factory/<builder>.py`; separate helper modules remain optional for more complex builders such as EDX and HISCALE.

The new private helpers cover:
- loading particle rows from PartMC netCDF fields
- selecting particle indices
- resolving target total number concentration
- rescaling selected number concentrations
- extracting gas mixing ratios

## Behavior preservation

This PR intentionally does **not** convert PartMC to `assemble_population_from_mass_fractions(...)`.

Reason: the current PartMC builder preserves exact per-species mass vectors from netCDF using `make_particle_from_masses(...)`. The shared mass-fraction assembly helper reconstructs masses from diameter/density/fraction assumptions and is not guaranteed to preserve those raw mass vectors at current test tolerances.

Unchanged:
- public builder type: `partmc`
- public config keys
- file/path behavior
- random selection semantics
- `N_tot` rescaling behavior
- exact mass construction via `make_particle_from_masses(...)`
- `ParticlePopulation.set_particle(...)` path
- `species_modifications` / `specdata_path` behavior
- optional `gas_mixing_ratios` attachment behavior

MAM4 is intentionally out of scope for this PR.

## Tests

Ran:

```bash
pytest tests/unit/population/factory/test_partmc.py -q
pytest tests/unit/population -q
````

Results:

* `tests/unit/population/factory/test_partmc.py`: 14 passed
* `tests/unit/population`: 163 passed, 3 warnings

## Not included / follow-ups

* MAM4 cleanup will be handled separately.
* Species alias resolution across builders remains deferred to #51.
