### PR TITLE
feat(species): resolve aliases in species-list builders

### DIFF
--- a/src/part2pop/population/factory/binned_lognormals.py
+++ b/src/part2pop/population/factory/binned_lognormals.py
@@ -9,6 +9,7 @@ from ..base import ParticlePopulation
 from ..utils import expand_compounds_for_population, normalize_population_config
 from part2pop import make_particle
 from part2pop.species.registry import get_species
+from part2pop.species.resolution import resolve_species_name_rows
 from .registry import register
 from scipy.stats import norm
 import numpy as np
@@ -51,7 +52,7 @@ def build(config):
         if not (global_D_min > 0 and global_D_max > 0 and global_D_min < global_D_max):
             raise ValueError("D_min and D_max must be positive and D_min < D_max.")
     
-    aero_spec_names_list = config['aero_spec_names']
+    aero_spec_names_list = resolve_species_name_rows(config['aero_spec_names'])
     aero_spec_fracs_list = config['aero_spec_fracs']
     # Support compound-like species names (e.g., NaCl, (NH4)2SO4)
     # aero_spec_names_list, aero_spec_fracs_list = expand_compounds_for_population(

--- a/src/part2pop/population/factory/monodisperse.py
+++ b/src/part2pop/population/factory/monodisperse.py
@@ -9,13 +9,14 @@ from ..base import ParticlePopulation
 from ..utils import normalize_population_config
 from part2pop import make_particle
 from part2pop.species.registry import get_species
+from part2pop.species.resolution import resolve_species_name_rows
 import numpy as np
 from .registry import register
 
 @register("monodisperse")
 def build(config):
     config = normalize_population_config(config)
-    aero_spec_names = config['aero_spec_names']
+    aero_spec_names = resolve_species_name_rows(config['aero_spec_names'])
     species_modifications = config.get('species_modifications', {})
     N = config['N']
     D = config['D']

--- a/src/part2pop/species/resolution.py
+++ b/src/part2pop/species/resolution.py
@@ -64,3 +64,10 @@ def resolve_species_names(
 ) -> list[str]:
     """Resolve a sequence of source labels in order."""
     return [resolve_species_name(name, aliases=aliases) for name in names]
+
+
+def resolve_species_name_rows(
+    name_rows: Sequence[Sequence[str]], aliases: Mapping[str, str] | None = None
+) -> list[list[str]]:
+    """Resolve a nested sequence of source labels while preserving shape/order."""
+    return [resolve_species_names(row, aliases=aliases) for row in name_rows]

--- a/tests/unit/population/factory/test_binned_lognormals.py
+++ b/tests/unit/population/factory/test_binned_lognormals.py
@@ -119,3 +119,33 @@ def test_binned_lognormals_accepts_stringy_numbers():
 
     N_tot = float(pop.get_Ntot())
     assert np.isclose(N_tot, 1e8, rtol=0.02)
+
+
+def test_binned_lognormals_resolves_alias_species_names_to_canonical_species_names():
+    alias_cfg = {
+        "type": "binned_lognormals",
+        "GMD": [0.05e-6, 0.15e-6],
+        "GSD": [1.4, 1.7],
+        "N": [5e7, 2e8],
+        "N_bins": [20, 30],
+        "aero_spec_names": [["dust", "soot"], ["org", "SO4"]],
+        "aero_spec_fracs": [[0.4, 0.6], [0.7, 0.3]],
+    }
+    canonical_cfg = {
+        "type": "binned_lognormals",
+        "GMD": [0.05e-6, 0.15e-6],
+        "GSD": [1.4, 1.7],
+        "N": [5e7, 2e8],
+        "N_bins": [20, 30],
+        "aero_spec_names": [["OIN", "BC"], ["OC", "SO4"]],
+        "aero_spec_fracs": [[0.4, 0.6], [0.7, 0.3]],
+    }
+
+    alias_pop = build_population(alias_cfg)
+    canonical_pop = build_population(canonical_cfg)
+
+    alias_names = [sp.name for sp in alias_pop.species]
+    canonical_names = [sp.name for sp in canonical_pop.species]
+    assert alias_names == canonical_names
+    assert alias_names[:4] == ["OIN", "BC", "OC", "SO4"]
+    assert np.isclose(float(alias_pop.get_Ntot()), float(canonical_pop.get_Ntot()), rtol=0.02)

--- a/tests/unit/population/factory/test_monodisperse.py
+++ b/tests/unit/population/factory/test_monodisperse.py
@@ -74,3 +74,29 @@ def test_monodisperse_accepts_stringy_numbers():
 
     assert len(pop.ids) == 1
     assert np.isclose(pop.get_Ntot(), 3.0)
+
+
+def test_monodisperse_resolves_alias_species_names_to_canonical_species_names():
+    alias_cfg = {
+        "type": "monodisperse",
+        "aero_spec_names": [["dust", "soot", "org"]],
+        "N": [2.0],
+        "D": [1e-7],
+        "aero_spec_fracs": [[0.2, 0.3, 0.5]],
+    }
+    canonical_cfg = {
+        "type": "monodisperse",
+        "aero_spec_names": [["OIN", "BC", "OC"]],
+        "N": [2.0],
+        "D": [1e-7],
+        "aero_spec_fracs": [[0.2, 0.3, 0.5]],
+    }
+
+    alias_pop = build_population(alias_cfg)
+    canonical_pop = build_population(canonical_cfg)
+
+    alias_names = [sp.name for sp in alias_pop.species]
+    canonical_names = [sp.name for sp in canonical_pop.species]
+    assert alias_names == canonical_names
+    assert alias_names[:3] == ["OIN", "BC", "OC"]
+    assert np.isclose(alias_pop.get_Ntot(), canonical_pop.get_Ntot())

--- a/tests/unit/species/test_resolution.py
+++ b/tests/unit/species/test_resolution.py
@@ -1,4 +1,5 @@
 from part2pop.species import resolve_species_name, resolve_species_names
+from part2pop.species.resolution import resolve_species_name_rows
 
 
 def test_default_aliases_resolve_expected_labels():
@@ -36,3 +37,17 @@ def test_user_aliases_override_defaults_for_single_call():
 def test_resolve_species_names_resolves_sequence_in_order():
     resolved = resolve_species_names(["Dust", "soot", "SO4", "black_carbon"])
     assert resolved == ["OIN", "BC", "SO4", "BC"]
+
+
+def test_resolve_species_name_rows_resolves_nested_rows_preserving_order_and_shape():
+    rows = [["Dust", "SO4"], ["soot", "Org", "NH4"]]
+    resolved = resolve_species_name_rows(rows)
+    assert resolved == [["OIN", "SO4"], ["BC", "OC", "NH4"]]
+    assert len(resolved) == len(rows)
+    assert [len(r) for r in resolved] == [len(r) for r in rows]
+
+
+def test_resolve_species_name_rows_canonical_and_alias_mixed_and_duplicates_preserved():
+    rows = [["BC", "black carbon", "BC"], ["OC", "poa", "SO4"]]
+    resolved = resolve_species_name_rows(rows)
+    assert resolved == [["BC", "BC", "BC"], ["OC", "OC", "SO4"]]


### PR DESCRIPTION
## Summary

Part of #51.

This PR applies species-name alias resolution to direct species-list population builders:

- `monodisperse`
- `binned_lognormals`

It adds a shared nested-list resolver for `aero_spec_names` rows and applies it before species lookup/population construction.

Canonical species names continue to behave as before. Alias names now resolve to canonical species-name strings before particle construction.

## Scope

Included:

- `src/part2pop/species/resolution.py`
  - added helper for resolving nested species-name rows
- `src/part2pop/population/factory/monodisperse.py`
  - resolves `config["aero_spec_names"]`
- `src/part2pop/population/factory/binned_lognormals.py`
  - resolves `config["aero_spec_names"]`

Out of scope:

- EDX elemental-to-species reconstruction
- HISCALE `mass_thresholds`
- MAM4
- PartMC
- `species_modifications` key resolution
- dictionary-key collision policy
- native/default species vocabulary redesign
- `H2O` particle-construction behavior

## Notes

This PR intentionally does not change `make_particle(...)` behavior. Particles constructed through `make_particle(...)` continue to include `H2O` internally when omitted by user config. The new tests compare alias and canonical configs rather than requiring `H2O` to be absent.

## Tests

Ran:

```bash
pytest tests/unit/species/test_resolution.py -q
pytest tests/unit/population/factory/test_monodisperse.py -q
pytest tests/unit/population/factory/test_binned_lognormals.py -q
pytest tests/unit/population/factory -q
````

Results:

* `tests/unit/species/test_resolution.py`: 8 passed
* `tests/unit/population/factory/test_monodisperse.py`: 4 passed, 1 warning
* `tests/unit/population/factory/test_binned_lognormals.py`: 6 passed, 1 warning
* `tests/unit/population/factory`: 105 passed, 5 warnings

## Follow-ups

* Handle HISCALE species-name alias resolution separately, if needed, with HISCALE-specific tests.
* Track EDX elemental-to-species reconstruction assumptions in a separate issue/PR.
* Define a future policy for dictionary-key alias resolution and collisions.
