### PR TITLE
docs: finalize release documentation and metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,10 +1,16 @@
 cff-version: 1.2.0
-title: part2pop
-message: "Please cite part2pop if you use it in your research."
+title: "part2pop"
+message: "Please cite both the part2pop JOSS paper and the archived Zenodo software release for the version used in your research."
+type: software
 authors:
   - family-names: Fierce
     given-names: Laura
-# fixme: add zenodo ID
-doi: 10.5281/zenodo.xxxxxxx 
+    orcid: "https://orcid.org/0000-0002-8682-1453"
+  - family-names: Beeler
+    given-names: Payton
+    orcid: "https://orcid.org/0000-0003-4759-1461"
+version: "1.0.0"
+repository-code: "https://github.com/pnnl/part2pop"
+license: MIT
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to part2pop
+
+Thank you for your interest in improving `part2pop`.
+
+## Support and feature requests
+
+- Report bugs using GitHub Issues.
+- Request new features using GitHub Issues.
+
+## Contribution workflow
+
+- Use pull requests for all contributions.
+- Create a branch for your change and keep each pull request focused on a single topic/scope.
+
+## Pre-PR checks
+
+Before opening a pull request, run:
+
+```bash
+pytest tests/unit -q
+pytest tests/integration -q
+```
+
+For docs-only changes, also run:
+
+```bash
+git diff --check
+```

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -1,30 +1,28 @@
 # part2pop
 
-A modular Python toolkit for scaling particle-level models to predict population-level aerosol effects.
+A unified analysis framework for standardizing aerosol populations from models, observations, and parameterizations.
 
-`part2pop` is a lightweight Python library that provides a **standardized representation of aerosol particles and populations**, together with modular builders for species, particle populations, optical properties, freezing properties, and analysis tools.
+`part2pop` is a lightweight Python library that provides a standardized representation of aerosol particles and populations. By translating model-derived, observation-constrained, and parameterized population descriptions into a common particle-population interface, `part2pop` lets particle-level process models and diagnostics be applied consistently across data sources. Its modular, registry-based architecture supports extensible population builders, reusable analyses, and AI-assisted development workflows.
 
-Its **builder/registry design** makes the system easily extensible: new population types, particle morphologies, freezing parameterizations, or species definitions can be added by placing small modules into the appropriate factory directory—without modifying core code.
-
-The framework enables reproducible process-level investigations, sensitivity studies, and intercomparison analyses across diverse model and observational datasets by providing a consistent interface for aerosol populations derived from models, measurements, or parameterized distributions.
+The framework supports reproducible process-level investigations, sensitivity studies, and intercomparison analyses by providing a consistent interface for aerosol populations derived from models, measurements, and parameterized distributions.
 
 ## Features
 
-- **Standardized aerosol representation** via `AerosolSpecies`, `AerosolParticle`, and `ParticlePopulation`
-- **Species registry** with density, refractive index, hygroscopicity, and thermodynamic properties
-- **Population builders** for monodisperse, lognormal, sampled, and model-derived populations
-- **Optical-property builders** supporting homogeneous spheres, core–shell particles, and fractal aggregates
+- **Standardized aerosol representation** via `AerosolSpecies`, `Particle`, and `ParticlePopulation`
+- **Species registry** with density, hygroscopicity (`kappa`), molar mass, and surface tension
+- **Population builders** for monodisperse, lognormal, sampled, observation-based, and model-derived populations
+- **Optical-property builders** supporting homogeneous spheres, core-shell particles, and fractal aggregates
 - **Freezing-property builders** for immersion-freezing metrics
-- **Analysis utilities** for size distributions, hygroscopic growth, CCN activation, and bulk moments
+- **Analysis utilities** for size distributions, hygroscopic growth, CCN activation, optical properties, and bulk moments
 - **Visualization tools** for size distributions, optical coefficients, and freezing curves
 
-Optional external packages (e.g., PyMieScatt, pyBCabs, netCDF4) are used when available.
+Optional external packages, including `PyMieScatt`, `pyBCabs`, and `netCDF4`, are used when available.
 
 ## Installation
 
 ```bash
 pip install part2pop
-```
+````
 
 For development:
 
@@ -41,35 +39,42 @@ from part2pop.population.builder import build_population
 
 config = {
     "type": "monodisperse",
-    "diameter": 0.2e-6,
-    "species_masses": {"SO4": 1e-15, "BC": 5e-16},
+    "N": [1.0e8],
+    "D": [0.2e-6],
+    "aero_spec_names": [["SO4", "BC"]],
+    "aero_spec_fracs": [[0.7, 0.3]],
+    "D_is_wet": False,
 }
 
 pop = build_population(config)
-print(pop)
+
+print(pop.get_Ntot())
+print([species.name for species in pop.species])
 ```
 
-More examples are available in the project repository.
+For end-to-end analysis and plotting workflows, see the notebooks in the [examples directory](https://github.com/pnnl/part2pop/tree/main/examples).
 
 ## Interactive viewer
 
 An experimental Streamlit UI lets you build populations through the factory registries and render existing visualization builders.
+
+For a source checkout, run:
 
 ```bash
 pip install -e .
 streamlit run scripts/launch_viewer.py
 ```
 
-The viewer source lives under `viewer/`. The sidebar lists every registered population and plot type; choose any combination, adjust the metadata-driven controls, and the figure plus diagnostics render inline.
+The viewer source lives under `viewer/`. The sidebar lists registered population and plot types; choose a population and visualization workflow, adjust the metadata-driven controls, and render figures and diagnostics interactively.
 
 ## Contributing
 
-`part2pop` is designed so that **all extensibility happens through factories**.
-
-New population types, optical morphologies, freezing parameterizations, diagnostics, and visualization types can be added by placing small modules in the appropriate factory directories without changing the core API.
+`part2pop` is designed so that new population types, optical morphologies, freezing parameterizations, diagnostics, and visualization types can be added through factory/registry modules without changing the core population representation.
 
 Please open an issue or pull request to discuss proposed additions.
 
+See the [contribution guidelines](https://github.com/pnnl/part2pop/blob/main/CONTRIBUTING.md) for contribution and support information.
+
 ## License
 
-See the `LICENSE` file in the repository.
+See the [LICENSE](https://github.com/pnnl/part2pop/blob/main/LICENSE) file in the repository.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,8 +58,11 @@ Related module families:
 - Document extension points and contracts.
 - Expand public API and registry tests.
 
-### Explicitly deferred (Priority 2)
+### Current status and deferred follow-up
 
-- Observation-based builder internal refactors (`EDX`, `HISCALE`).
-- Model-derived builder cleanup (`PartMC`, `MAM4`).
-- Deeper reconstruction-strategy and translator architecture work.
+- Observation-based builders (`edx_observations`, `hiscale_observations`) now include helper-layer cleanup/splitting in place.
+- Model-derived builders:
+  - `partmc` row-preparation cleanup was completed in place.
+  - `mam4` remains intentionally thin and delegates to `binned_lognormals`.
+- Species-name alias resolution currently applies to direct species-list builders `monodisperse` and `binned_lognormals`.
+- EDX elemental-to-species reconstruction clarification remains a follow-up issue and is not part of JOSS release finalization.

--- a/docs/population_builders.md
+++ b/docs/population_builders.md
@@ -24,16 +24,16 @@
 
 ## Builder categories
 
-- Distribution builders (current Priority 1 baseline):
+- Direct species-list / distribution builders:
   - `monodisperse`
   - `binned_lognormals`
   - `sampled_lognormals`
-- Observation-constrained builders (deeper refactor deferred to Priority 2):
-  - `EDX`
-  - `HISCALE`
-- Model-derived builders (cleanup deferred to Priority 2):
-  - `PartMC`
-  - `MAM4`
+- Observation-based builders:
+  - `edx_observations`
+  - `hiscale_observations`
+- Model-derived builders:
+  - `partmc`
+  - `mam4`
 
 ## How to add a new extension
 
@@ -47,7 +47,8 @@
 
 - Location: `src/part2pop/population/factory/`
 - Pattern: one builder per module, lowercase filename, no leading `_`.
-- Large builders may keep internal support code in:
+- Simple builders can remain self-contained in a single factory module.
+- Larger builders may keep internal support code in:
   - `src/part2pop/population/factory/helpers/`
 - `helpers/` is internal and is **not** a builder plugin location.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,8 +7,7 @@
 - This roadmap is intentionally **not** a source-code refactor PR.
 - It records:
   - completed JOSS-prep work,
-  - active Phase 2 cleanup work,
-  - deferred architecture work,
+  - completed and deferred builder-architecture work,
   - future-facing wishlist items.
 
 ## Maintenance note
@@ -104,7 +103,7 @@ Deferred work is tracked below rather than being mixed into the release-stabiliz
 
 ---
 
-## Active Phase 2 — population builder cleanup
+## Population builder cleanup status (post-Phase-2 implementation pass)
 
 Phase 2 focuses on cleaning up population-builder architecture, especially observation- and model-derived builders, while preserving public APIs.
 
@@ -143,11 +142,11 @@ population/
       model_translation.py
 ```
 
-### Current active task: HISCALE explicit-row assembly
+### Completed implementation outcomes
 
-Goal:
+Completed:
 
-* Add and stabilize an internal helper:
+* Internal helper added/stabilized:
 
 ```text
 src/part2pop/population/factory/helpers/assembly.py
@@ -171,7 +170,7 @@ ParticlePopulation.spec_masses: 2D, shape (n_particles, n_species)
 ParticlePopulation.num_concs: 1D, shape (n_particles,)
 ```
 
-Current design decision:
+Implemented design:
 
 * `hiscale_observations` should **not** route explicit particle rows through `monodisperse`.
 * `hiscale_observations` should call the internal assembly helper directly once it has produced:
@@ -181,14 +180,14 @@ Current design decision:
   * `aero_spec_names`
   * `aero_spec_fracs`
 
-Current bug under diagnosis:
+Resolved shape-regression target:
 
 ```text
 ParticlePopulation.spec_masses becomes shape (1000, 1, 3)
 Expected shape is (1000, 3)
 ```
 
-Immediate rule:
+Outcome:
 
 * Diagnose with targeted shape instrumentation before patching.
 * Do not blindly change:
@@ -198,7 +197,7 @@ Immediate rule:
   * `ParticlePopulation`
   * `population/base.py`
 
-### Observation-based builder refactor
+### Observation-based builders
 
 Builders:
 
@@ -218,13 +217,13 @@ reader
 
 Current status:
 
-* HISCALE direct-to-assembler wiring is active.
-* Full HISCALE reader/selector/reconstruction split is deferred.
-* EDX direct-to-assembler cleanup is a likely next Phase 2 follow-up.
+* HISCALE direct-to-assembler wiring is in place.
+* EDX/HISCALE helper-layer cleanup/splitting is in place for current release scope.
+* Additional EDX elemental-to-species reconstruction clarification remains a follow-up item.
 
 ### Shared assembly and metadata improvements
 
-Active/near-term:
+Completed/near-term:
 
 * Add shared population assembly helper.
 * Add focused tests for helper shape contracts.
@@ -274,7 +273,7 @@ Important boundary:
 * The assembler should primarily assemble already-resolved species rows.
 * Builder-specific source labels should be resolved upstream of assembly.
 
-### Model-derived builder cleanup
+### Model-derived builders
 
 Builders:
 
@@ -291,7 +290,10 @@ model-native representation
 → shared population assembly
 ```
 
-Deferred questions:
+Current status / deferred questions:
+
+* `partmc` row-preparation cleanup was completed in place.
+* `mam4` was inspected and remains intentionally thin because it delegates to `binned_lognormals`.
 
 * What belongs in `part2pop`?
 * What belongs in AMBRS?

--- a/docs/species.md
+++ b/docs/species.md
@@ -61,6 +61,13 @@ print(describe_species("MY_SPEC"))
 - `get_species(..., specdata_path=...)` can point to an alternate species data folder.
 - If `specdata_path` is `None`, package default data is used.
 
+## Species-name alias resolution
+
+- Canonical species names remain the internal basis for species lookup and population assembly.
+- Direct species-list builders currently resolve common aliases before species lookup.
+- Current scope includes `monodisperse` and `binned_lognormals`.
+- Alias resolution applies to species-name strings and does not operate on already-constructed `AerosolSpecies` objects.
+
 ## What not to do / deferred work
 
 - Do not introduce a new species metadata schema in this phase.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "part2pop"
-version = "0.1.1"
-description = "A modular Python toolkit to build, analyze, and extend aerosol particle populations."
+version = "1.0.0"
+description = "A unified analysis framework for standardizing aerosol populations from models, observations, and parameterizations."
 readme = { file = "README.pypi.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

This PR finalizes documentation and release metadata for the pre-JOSS `part2pop` 1.0.0 release.

Changes include:
- updates README and PyPI README positioning and quick-start documentation
- adds contributor/support guidance in `CONTRIBUTING.md`
- updates architecture, species, population-builder, and roadmap docs for current builder/refactor status
- bumps package metadata to `1.0.0`
- updates `CITATION.cff` and removes the placeholder Zenodo DOI

## Scope

Documentation and release metadata only. No source-code behavior changes.

## Checks

- README quick-start smoke test
- `pytest tests/unit -q`
- `pytest tests/integration -q`
- `git diff --check`