### PR TITLE
Test/coverage low hanging fruit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.12"]
 
     steps:
       - name: Checkout repository
@@ -38,7 +38,7 @@ jobs:
           pytest tests/unit --cov=part2pop --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
-        if: ${{ matrix.python-version == '3.11' }}
+        if: ${{ matrix.python-version == '3.14' }}
         uses: codecov/codecov-action@v5
         with:                          
           files: ./coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,16 @@ keywords = [
 ]
 
 classifiers = [
-  "Development Status :: 3 - Alpha",
   "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Atmospheric Science",
 ]

--- a/src/part2pop/analysis/population/factory/INSA_grid.py
+++ b/src/part2pop/analysis/population/factory/INSA_grid.py
@@ -12,17 +12,17 @@ class InsaGridVar(PopulationVariable):
         description="Particle ice nucleating surface area grid",
         units="m$^2$",
         scale="log",
-        long_label = "ice nucelating surface area",
+        long_label = "ice nucleating surface area",
         short_label = "INSA",
     # axis/grid defaults are centralized in analysis.defaults
     default_cfg={},
-    #aliases=("insa_grid"),
+    aliases=("insa_grid",),
     )
     def compute(self, population, as_dict=False):
         cfg = self.cfg
         vals = cfg.get("insa_grid")
         if as_dict:
-            return {"insa_grid": np.asarray(vals)}
+            return {"INSA_grid": np.asarray(vals)}
         else:
             return np.asarray(vals)
 

--- a/tests/unit/analysis/population/factory/test_INSA_grid.py
+++ b/tests/unit/analysis/population/factory/test_INSA_grid.py
@@ -1,0 +1,23 @@
+import importlib
+import numpy as np
+
+import part2pop.analysis.population.factory.INSA_grid as insa_grid_mod
+
+
+def test_import_insa_grid():
+    # Smoke test: module should import successfully
+    importlib.import_module("part2pop.analysis.population.factory.INSA_grid")
+
+
+def test_insa_grid_compute_array_and_dict():
+    var = insa_grid_mod.build({"insa_grid": [1e-12, 2e-12, 4e-12]})
+
+    out = var.compute(population=None)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (3,)
+    assert np.allclose(out, [1e-12, 2e-12, 4e-12])
+
+    out_dict = var.compute(population=None, as_dict=True)
+    assert set(out_dict) == {"insa_grid"}
+    assert isinstance(out_dict["insa_grid"], np.ndarray)
+    assert np.allclose(out_dict["insa_grid"], out)

--- a/tests/unit/analysis/population/factory/test_INSA_grid.py
+++ b/tests/unit/analysis/population/factory/test_INSA_grid.py
@@ -2,6 +2,7 @@ import importlib
 import numpy as np
 
 import part2pop.analysis.population.factory.INSA_grid as insa_grid_mod
+from part2pop.analysis.population.factory import registry as pop_factory_registry
 
 
 def test_import_insa_grid():
@@ -18,6 +19,14 @@ def test_insa_grid_compute_array_and_dict():
     assert np.allclose(out, [1e-12, 2e-12, 4e-12])
 
     out_dict = var.compute(population=None, as_dict=True)
-    assert set(out_dict) == {"insa_grid"}
-    assert isinstance(out_dict["insa_grid"], np.ndarray)
-    assert np.allclose(out_dict["insa_grid"], out)
+    assert set(out_dict) == {"INSA_grid"}
+    assert isinstance(out_dict["INSA_grid"], np.ndarray)
+    assert np.allclose(out_dict["INSA_grid"], out)
+
+
+def test_insa_grid_registry_alias_and_value_key_consistency():
+    assert pop_factory_registry.resolve_name("insa_grid") == "INSA_grid"
+    builder = pop_factory_registry.get_population_builder("insa_grid")
+    var = builder({"insa_grid": [1e-12]})
+    assert var.meta.name == "INSA_grid"
+    assert "insa_grid" in var.meta.aliases

--- a/tests/unit/analysis/population/factory/test_b_abs.py
+++ b/tests/unit/analysis/population/factory/test_b_abs.py
@@ -1,5 +1,52 @@
 import importlib
+import numpy as np
+
+import part2pop.analysis.population.factory.b_abs as b_abs_mod
 
 def test_import_b_abs():
     # Smoke test: module should import successfully
     importlib.import_module("part2pop.analysis.population.factory.b_abs")
+
+
+def test_b_abs_compute_and_as_dict_with_wvls_alias(monkeypatch):
+    captured = {}
+    expected = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    class _FakeOpticalPopulation:
+        def get_optical_coeff(self, name, rh=None, wvl=None):
+            captured["coeff_name"] = name
+            captured["rh"] = rh
+            captured["wvl"] = wvl
+            return expected
+
+    def _fake_build_optical_population(population, ocfg):
+        captured["population"] = population
+        captured["ocfg"] = ocfg
+        return _FakeOpticalPopulation()
+
+    monkeypatch.setattr(b_abs_mod, "build_optical_population", _fake_build_optical_population)
+
+    cfg = {
+        "morphology": "core-shell",
+        "rh_grid": [0.2, 0.8],
+        "wvls": [500e-9, 700e-9],
+        "T": 298.15,
+        "species_modifications": {"BC": {"density": 1700.0}},
+    }
+    pop = object()
+    var = b_abs_mod.build(cfg)
+
+    out = var.compute(pop)
+    assert np.allclose(out, expected)
+    assert captured["coeff_name"] == "b_abs"
+    assert captured["ocfg"]["type"] == "core_shell"
+    assert captured["ocfg"]["rh_grid"] == [0.2, 0.8]
+    assert captured["ocfg"]["wvl_grid"] == [500e-9, 700e-9]
+    assert captured["ocfg"]["temp"] == 298.15
+    assert captured["ocfg"]["species_modifications"] == {"BC": {"density": 1700.0}}
+
+    out_dict = var.compute(pop, as_dict=True)
+    assert set(out_dict) == {"rh_grid", "wvl_grid", "b_abs"}
+    assert np.allclose(out_dict["rh_grid"], [0.2, 0.8])
+    assert np.allclose(out_dict["wvl_grid"], [500e-9, 700e-9])
+    assert np.allclose(out_dict["b_abs"], expected)

--- a/tests/unit/analysis/population/factory/test_b_ext.py
+++ b/tests/unit/analysis/population/factory/test_b_ext.py
@@ -1,5 +1,47 @@
 import importlib
+import numpy as np
+
+import part2pop.analysis.population.factory.b_ext as b_ext_mod
 
 def test_import_b_ext():
     # Smoke test: module should import successfully
     importlib.import_module("part2pop.analysis.population.factory.b_ext")
+
+
+def test_b_ext_compute_and_as_dict(monkeypatch):
+    captured = {}
+    expected = np.array([[10.0, 20.0]])
+
+    class _FakeOpticalPopulation:
+        def get_optical_coeff(self, name, rh=None, wvl=None):
+            captured["coeff_name"] = name
+            return expected
+
+    def _fake_build_optical_population(population, ocfg):
+        captured["ocfg"] = ocfg
+        return _FakeOpticalPopulation()
+
+    monkeypatch.setattr(b_ext_mod, "build_optical_population", _fake_build_optical_population)
+
+    cfg = {
+        "morphology": "core-shell",
+        "rh_grid": [0.4],
+        "wvl_grid": [532e-9, 660e-9],
+        "T": 290.0,
+        "species_modifications": {"SO4": {"kappa": 0.6}},
+    }
+    var = b_ext_mod.build(cfg)
+    out = var.compute(object())
+    assert np.allclose(out, expected)
+    assert captured["coeff_name"] == "b_ext"
+    assert captured["ocfg"]["type"] == "core_shell"
+    assert captured["ocfg"]["rh_grid"] == [0.4]
+    assert captured["ocfg"]["wvl_grid"] == [532e-9, 660e-9]
+    assert captured["ocfg"]["temp"] == 290.0
+    assert captured["ocfg"]["species_modifications"] == {"SO4": {"kappa": 0.6}}
+
+    out_dict = var.compute(object(), as_dict=True)
+    assert set(out_dict) == {"rh_grid", "wvl_grid", "b_ext"}
+    assert np.allclose(out_dict["rh_grid"], [0.4])
+    assert np.allclose(out_dict["wvl_grid"], [532e-9, 660e-9])
+    assert np.allclose(out_dict["b_ext"], expected)

--- a/tests/unit/analysis/population/factory/test_b_scat.py
+++ b/tests/unit/analysis/population/factory/test_b_scat.py
@@ -1,5 +1,47 @@
 import importlib
+import numpy as np
+
+import part2pop.analysis.population.factory.b_scat as b_scat_mod
 
 def test_import_b_scat():
     # Smoke test: module should import successfully
     importlib.import_module("part2pop.analysis.population.factory.b_scat")
+
+
+def test_b_scat_compute_and_as_dict_with_wvls_alias(monkeypatch):
+    captured = {}
+    expected = np.array([[0.1, 0.2, 0.3]])
+
+    class _FakeOpticalPopulation:
+        def get_optical_coeff(self, name, rh=None, wvl=None):
+            captured["coeff_name"] = name
+            return expected
+
+    def _fake_build_optical_population(population, ocfg):
+        captured["ocfg"] = ocfg
+        return _FakeOpticalPopulation()
+
+    monkeypatch.setattr(b_scat_mod, "build_optical_population", _fake_build_optical_population)
+
+    cfg = {
+        "morphology": "core-shell",
+        "rh_grid": [0.1],
+        "wvls": [450e-9, 550e-9, 650e-9],
+        "T": 300.0,
+        "species_modifications": {},
+    }
+    var = b_scat_mod.build(cfg)
+    out = var.compute(object())
+    assert np.allclose(out, expected)
+    assert captured["coeff_name"] == "b_scat"
+    assert captured["ocfg"]["type"] == "core_shell"
+    assert captured["ocfg"]["rh_grid"] == [0.1]
+    assert captured["ocfg"]["wvl_grid"] == [450e-9, 550e-9, 650e-9]
+    assert captured["ocfg"]["temp"] == 300.0
+    assert captured["ocfg"]["species_modifications"] == {}
+
+    out_dict = var.compute(object(), as_dict=True)
+    assert set(out_dict) == {"rh_grid", "wvl_grid", "b_scat"}
+    assert np.allclose(out_dict["rh_grid"], [0.1])
+    assert np.allclose(out_dict["wvl_grid"], [450e-9, 550e-9, 650e-9])
+    assert np.allclose(out_dict["b_scat"], expected)

--- a/tests/unit/analysis/population/factory/test_diam_grid.py
+++ b/tests/unit/analysis/population/factory/test_diam_grid.py
@@ -1,5 +1,24 @@
 import importlib
+import numpy as np
+
+import part2pop.analysis.population.factory.diam_grid as diam_grid_mod
+
 
 def test_import_diam_grid():
     # Smoke test: module should import successfully
     importlib.import_module("part2pop.analysis.population.factory.diam_grid")
+
+
+def test_diam_grid_compute_array_and_dict():
+    cfg = {"diam_grid": [1e-9, 2e-9, 5e-9]}
+    var = diam_grid_mod.build(cfg)
+
+    out = var.compute(population=None)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (3,)
+    assert np.allclose(out, [1e-9, 2e-9, 5e-9])
+
+    out_dict = var.compute(population=None, as_dict=True)
+    assert set(out_dict) == {"diam_grid"}
+    assert isinstance(out_dict["diam_grid"], np.ndarray)
+    assert np.allclose(out_dict["diam_grid"], out)

--- a/tests/unit/analysis/population/factory/test_rh_grid.py
+++ b/tests/unit/analysis/population/factory/test_rh_grid.py
@@ -1,5 +1,27 @@
 import importlib
+import numpy as np
+
+import part2pop.analysis.population.factory.rh_grid as rh_grid_mod
 
 def test_import_rh_grid():
     # Smoke test: module should import successfully
     importlib.import_module("part2pop.analysis.population.factory.rh_grid")
+
+
+def test_rh_grid_default_and_explicit_with_dict_output():
+    default_var = rh_grid_mod.build({})
+    default_out = default_var.compute(population=None)
+    assert isinstance(default_out, np.ndarray)
+    assert default_out.shape == (1,)
+    assert np.allclose(default_out, [0.0])
+
+    var = rh_grid_mod.build({"rh_grid": [0.25, 0.5, 0.9]})
+    out = var.compute(population=None)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (3,)
+    assert np.allclose(out, [0.25, 0.5, 0.9])
+
+    out_dict = var.compute(population=None, as_dict=True)
+    assert set(out_dict) == {"rh_grid"}
+    assert isinstance(out_dict["rh_grid"], np.ndarray)
+    assert np.allclose(out_dict["rh_grid"], out)

--- a/tests/unit/analysis/population/factory/test_s_grid.py
+++ b/tests/unit/analysis/population/factory/test_s_grid.py
@@ -1,5 +1,26 @@
 import importlib
+import numpy as np
+
+import part2pop.analysis.population.factory.s_grid as s_grid_mod
 
 def test_import_s_grid():
     # Smoke test: module should import successfully
     importlib.import_module("part2pop.analysis.population.factory.s_grid")
+
+
+def test_s_grid_explicit_and_alias_with_dict_output():
+    var = s_grid_mod.build({"s_grid": [0.1, 0.2, 0.5]})
+    out = var.compute(population=None)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (3,)
+    assert np.allclose(out, [0.1, 0.2, 0.5])
+
+    out_dict = var.compute(population=None, as_dict=True)
+    assert set(out_dict) == {"s_grid"}
+    assert np.allclose(out_dict["s_grid"], out)
+
+    alias_var = s_grid_mod.build({"s_eval": [0.05, 0.15]})
+    alias_out = alias_var.compute(population=None)
+    assert isinstance(alias_out, np.ndarray)
+    assert alias_out.shape == (2,)
+    assert np.allclose(alias_out, [0.05, 0.15])

--- a/tests/unit/analysis/population/factory/test_spec_mass_conc.py
+++ b/tests/unit/analysis/population/factory/test_spec_mass_conc.py
@@ -1,5 +1,53 @@
 import importlib
+import numpy as np
+
+import part2pop.analysis.population.factory.spec_mass_conc as spec_mass_conc_mod
+
+
+class _Species:
+    def __init__(self, name):
+        self.name = name
+
+
+class _PopulationWithMassConc:
+    def __init__(self, mass_conc):
+        self.species = [_Species(k) for k in mass_conc.keys()]
+        self._mass_conc = dict(mass_conc)
+
+    def get_species_mass_conc(self, spec_name):
+        return self._mass_conc[spec_name]
 
 def test_import_spec_mass_conc():
     # Smoke test: module should import successfully
     importlib.import_module("part2pop.analysis.population.factory.spec_mass_conc")
+
+
+def test_build_returns_variable_object():
+    var = spec_mass_conc_mod.build({})
+    assert var is not None
+    assert hasattr(var, "compute")
+
+
+def test_compute_uses_population_species_when_names_omitted():
+    pop = _PopulationWithMassConc({"SO4": 1.25, "BC": 2.5})
+    var = spec_mass_conc_mod.build({})
+    out = var.compute(pop)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (2,)
+    assert np.allclose(out, [1.25, 2.5])
+
+
+def test_compute_single_species_string_and_as_dict():
+    pop = _PopulationWithMassConc({"BC": 2.5})
+    var = spec_mass_conc_mod.build({"species_names": "BC"})
+
+    out = var.compute(pop)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (1,)
+    assert np.allclose(out, [2.5])
+
+    out_dict = var.compute(pop, as_dict=True)
+    assert set(out_dict) == {"species_names", "mass_conc"}
+    assert out_dict["species_names"] == ["BC"]
+    assert isinstance(out_dict["mass_conc"], np.ndarray)
+    assert np.allclose(out_dict["mass_conc"], out)

--- a/tests/unit/analysis/population/factory/test_time_grid.py
+++ b/tests/unit/analysis/population/factory/test_time_grid.py
@@ -1,0 +1,24 @@
+import importlib
+import numpy as np
+
+import part2pop.analysis.population.factory.time_grid as time_grid_mod
+
+
+def test_import_time_grid():
+    # Smoke test: module should import successfully
+    importlib.import_module("part2pop.analysis.population.factory.time_grid")
+
+
+def test_time_grid_default_and_explicit_values():
+    default_var = time_grid_mod.build({})
+    default_out = default_var.compute(population=None)
+    assert isinstance(default_out, np.ndarray)
+    assert default_out.shape == (721,)
+    assert np.allclose(default_out[:3], [0.0, 0.5, 1.0])
+    assert np.isclose(default_out[-1], 360.0)
+
+    var = time_grid_mod.build({"t_min": 1.0, "t_max": 2.0, "dt": 0.5})
+    out = var.compute(population=None)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (3,)
+    assert np.allclose(out, [1.0, 1.5, 2.0])

--- a/tests/unit/analysis/population/factory/test_wvl_grid.py
+++ b/tests/unit/analysis/population/factory/test_wvl_grid.py
@@ -1,5 +1,25 @@
 import importlib
+import numpy as np
+
+import part2pop.analysis.population.factory.wvl_grid as wvl_grid_mod
 
 def test_import_wvl_grid():
     # Smoke test: module should import successfully
     importlib.import_module("part2pop.analysis.population.factory.wvl_grid")
+
+
+def test_wvl_grid_default_explicit_and_dict_output():
+    default_var = wvl_grid_mod.build({})
+    default_out = default_var.compute(population=None)
+    assert isinstance(default_out, np.ndarray)
+    assert default_out.shape == (0,)
+
+    var = wvl_grid_mod.build({"wvl_grid": [500e-9, 700e-9]})
+    out = var.compute(population=None)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (2,)
+    assert np.allclose(out, [500e-9, 700e-9])
+
+    out_dict = var.compute(population=None, as_dict=True)
+    assert set(out_dict) == {"wvl_grid"}
+    assert np.allclose(out_dict["wvl_grid"], out)

--- a/tests/unit/population/factory/helpers/test_edx.py
+++ b/tests/unit/population/factory/helpers/test_edx.py
@@ -1,9 +1,13 @@
 import numpy as np
+import pytest
 
 from part2pop.population.factory.helpers.edx import (
     Population_MassFracs,
+    _normalize_or_raise,
     read_edx_file,
     reconstruct_edx_species_mass_fractions,
+    sample_bio_particle,
+    sample_particle,
 )
 
 
@@ -52,3 +56,43 @@ def test_reconstruct_edx_species_mass_fractions_dispatch_and_alignment(tmp_path)
     assert masses[class_to_row["biological"], biological_idx] > 0
     assert masses[class_to_row["carbonaceous"], so4_idx] == 0
     assert masses[class_to_row["dust"], so4_idx] > 0
+
+
+def test_read_edx_file_non_csv_raises(tmp_path):
+    bad = tmp_path / "bad.txt"
+    bad.write_text("x", encoding="utf-8")
+    with pytest.raises(ValueError, match="must be .csv"):
+        read_edx_file({"edx_file": str(bad)}, ["C", "O"])
+
+
+def test_read_edx_file_percent_and_wt_prefix_columns(tmp_path):
+    csv_path = tmp_path / "edx_wt.csv"
+    csv_path.write_text(
+        "diam_um,class,wt_C,wt_N,wt_O,wt_Na,wt_Mg,wt_Al,wt_Si,wt_P,wt_S,wt_Cl,wt_K,wt_Ca,wt_Mn,wt_Fe,wt_Zn\n"
+        "1.0,dust,20,10,39,5,3,2,2,3,3,5,1,2,1,2,2\n",
+        encoding="utf-8",
+    )
+    elems = ['C', 'N', 'O', 'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'K', 'Ca', 'Mn', 'Fe', 'Zn']
+    out = read_edx_file({"edx_file": str(csv_path)}, elems)
+    assert np.isclose(out.D[0], 1e-6)
+    assert np.isclose(np.sum(out.mass_fractions[0]), 1.0, atol=1e-12)
+
+
+def test_sample_particle_oxygen_limited_and_missing_species_raises():
+    elements = np.array(['C', 'N', 'O', 'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'K', 'Ca', 'Mn', 'Fe', 'Zn'])
+    mass_fracs = np.array([0.2, 0.05, 0.06, 0.05, 0.03, 0.02, 0.02, 0.01, 0.15, 0.05, 0.01, 0.02, 0.01, 0.02, 0.01])
+    with pytest.raises(ValueError, match="sum to"):
+        sample_particle(['SO4', 'OIN', 'OC', 'Na', 'Cl'], mass_fracs, elements)
+
+    with pytest.raises(ValueError, match="Could not find SO4"):
+        sample_particle(['OIN', 'OC', 'Na', 'Cl'], mass_fracs, elements)
+
+
+def test_sample_bio_particle_oxygen_limited_and_normalize_guard():
+    elements = np.array(['C', 'N', 'O', 'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'K', 'Ca', 'Mn', 'Fe', 'Zn'])
+    mass_fracs = np.array([0.2, 0.1, 0.02, 0.05, 0.04, 0.08, 0.08, 0.02, 0.1, 0.05, 0.04, 0.05, 0.03, 0.02, 0.02])
+    with pytest.raises(ValueError, match="sum to"):
+        sample_bio_particle(['OIN', 'biological', 'Na', 'Cl'], mass_fracs, elements)
+
+    with pytest.raises(ValueError, match="sum to"):
+        _normalize_or_raise(np.array([0.2, 0.2]))


### PR DESCRIPTION
## Summary

This PR adds focused unit-test coverage for low-hanging factory/helper paths and aligns Python support metadata with CI for the 1.0.0 release.

## Changes

### Tests
- Adds deterministic unit coverage for population analysis factory modules:
  - grid factories
  - optical coefficient wrappers
  - species mass concentration
  - selected EDX helper branches
- Keeps changes tests-only for the coverage commit.

### Release / CI metadata
- Updates CI Python matrix to avoid duplicate Python versions and cover advertised supported versions.
- Aligns `pyproject.toml` Python classifiers / support metadata for the 1.0.0 release.
- Keeps package version at `1.0.0`.

## Checks

Validated locally:

- `git diff --check`
- focused population factory tests
- full unit test suite with coverage

Latest local result:

- `453 passed, 20 warnings`
- total coverage: `92%`