### PR TITLE
updated paper.md for best-fit flowchart

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -18,9 +18,7 @@ affiliations:
     index: 1
 bibliography: paper.bib
 link-citations: true
-header-includes:
-  - \usepackage{float}
-  - \usepackage{placeins}
+fig-pos: tbp
 ---
 
 # Summary


### PR DESCRIPTION
Remove unsupported LaTeX header includes from the JOSS paper metadata after the draft PDF build failed because placeins.sty is not available in the Inara build image. Keep figure-placement metadata lightweight and avoid adding extra LaTeX package dependencies. This is a manuscript build/configuration fix only; figure content is unchanged.