### PR TITLE
Add Zenodo DOI (v1.0.0) to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
     given-names: Payton
     orcid: "https://orcid.org/0000-0003-4759-1461"
 version: "1.0.0"
+doi: 10.5281/zenodo.20034423
 repository-code: "https://github.com/pnnl/part2pop"
 license: MIT
-
 


### PR DESCRIPTION
## Summary

Adds the Zenodo DOI for the v1.0.0 release to `CITATION.cff` to improve citation metadata and align with the archived software release.

## Changes

- Added version-specific DOI: https://doi.org/10.5281/zenodo.20034423

## Notes

- This does not modify the existing Zenodo record for v1.0.0 (which is immutable), but ensures that:
  - GitHub’s citation metadata is correct
  - Future releases include the DOI in `CITATION.cff`

- JOSS DOI will be added in a follow-up update once available.