### PR TITLE
minor formatting changes to references, minor cleanup to init

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -240,7 +240,7 @@
 
 @article{Zelenyuk2015_JASMS_miniSPLAT,
   author = {Zelenyuk, Alla and Imre, Dan and Wilson, Jacqueline M. and Zhang, Zhiyuan and Wang, Jun and Mueller, Klaus},
-  title = {Airborne Single Particle Mass Spectrometers ({SPLAT} {II} and mini{SPLAT}) and New Software for Data Visualization and Analysis in a {Geo-Spatial} Context},
+  title = {Airborne Single Particle Mass Spectrometers ({SPLAT} {II} \& mini{SPLAT}) and New Software for Data Visualization and Analysis in a {Geo-Spatial} Context},
   journal = {Journal of the American Society for Mass Spectrometry},
   year = {2015},
   volume = {26},
@@ -331,4 +331,11 @@
   volume = {138},
   pages = {451--460},
   doi = {10.1039/C2AN36318F}
+}
+
+@misc{part2pop_zenodo,
+  author = {Fierce, Laura and Beeler, Payton},
+  title = {{part2pop} v1.0.0},
+  year = {2026},
+  doi = {10.5281/zenodo.20034423}
 }

--- a/src/part2pop/__init__.py
+++ b/src/part2pop/__init__.py
@@ -7,69 +7,6 @@ from pathlib import Path
 from importlib.resources import files, as_file
 import sys as _sys
 
-# __all__ = ["data_path", "get_data_path"]
-
-# def _discover_datasets_dir() -> Path | None:
-#     """
-#     Return a real filesystem Path to the packaged 'datasets' dir if present.
-#     Works for wheels/zip installs and editable installs.
-#     """
-#     # Use the actual imported top-level module object (rename/case safe)
-#     pkg_name = (__package__ or "part2pop").split(".", 1)[0]
-#     pkg_obj = _sys.modules.get(pkg_name, pkg_name)
-#     try:
-#         ds = files(pkg_obj).joinpath("datasets")
-#         if ds.is_dir():
-#             with as_file(ds) as p:
-#                 return Path(p)
-#     except Exception:
-#         pass
-#     # Fallback for source checkouts
-#     here = Path(__file__).resolve().parent
-#     cand = here / "datasets"
-#     return cand if cand.is_dir() else None
-
-# def get_data_path() -> Path:
-#     """
-#     Preferred datasets directory. If user set part2pop_DATA_PATH, honor it.
-#     Otherwise, return the packaged datasets path if available.
-#     """
-#     env = os.environ.get("part2pop_DATA_PATH")
-#     if env:
-#         return Path(env).expanduser()
-#     ds = _discover_datasets_dir()
-#     if ds:
-#         return ds
-#     # final fallback so we always return *something*
-#     return Path.cwd() / "datasets"
-
-# data_path: Path = get_data_path()
-
-# # Optional: make legacy env-based lookups "just work" without user config.
-# # Only set if user didn't already define it.
-# os.environ.setdefault("part2pop_DATA_PATH", str(data_path))
-
-
-# # def get_data_path() -> Path:
-# #     # Highest priority: explicit override
-# #     if (p := os.environ.get("part2pop_DATA_PATH")):
-# #         return Path(p).expanduser()
-
-# #     # Packaged datasets inside the installed wheel
-# #     ds = files(_pkg).joinpath("datasets")
-# #     if ds.is_dir():
-# #         # If callers need a filesystem path (e.g., for C libs), materialize it:
-# #         with as_file(ds) as pth:
-# #             return Path(pth)
-
-# #     # Last resort for source checkouts
-# #     from pathlib import Path as _P
-# #     cand = _P(__file__).resolve().parent / "datasets"
-# #     return cand
-
-# # data_path = get_data_path()
-# # __all__ = ["data_path", "get_data_path"]
-
 # Public helpers
 from .utilities import get_number
 


### PR DESCRIPTION
## Summary

Final cleanup and polish before the PyPI, Zenodo, and JOSS release.

## Changes

- remove generated `paper/paper.pdf` from version control
- remove internal release-planning docs:
  - `docs/decisions/0004-joss-release-scope.md`
  - `docs/roadmap.md`
- add draft JOSS PDF GitHub Actions workflow
- apply final packaging/code cleanup and related test updates

## Rationale

JOSS requires the paper source files (`paper.md`, BibTeX, and figures) to live in the repository, but generated PDFs do not need to be tracked. Internal release-planning notes and stale roadmap material were removed to keep the release repository focused on user-facing documentation and maintainable source code.

## Checks

- [x] `git diff --check`
- [x] `pytest tests/unit/population/test_base.py -q`
- [x] `pytest tests/unit -q`
- [x] `pytest tests/integration -q`
- [x] draft PDF workflow executes successfully